### PR TITLE
[22] Change of ATOM_INFO to use atom_type

### DIFF
--- a/hyperon_das/api.py
+++ b/hyperon_das/api.py
@@ -87,8 +87,7 @@ class DistributedAtomSpace:
                 is_link = 'targets' in deep_representation
                 result[variable] = {
                     **deep_representation,
-                    'is_link': is_link,
-                    'is_node': not is_link,
+                    'atom_type': 'link' if is_link else 'node',
                 }
             results.append(result)
         return results

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -352,8 +352,7 @@ class TestDistributedAtomSpace:
                 "V1": {
                     "type": "Predicate",
                     "name": "Predicate:has_name",
-                    'is_link': False,
-                    'is_node': True,
+                    'atom_type': 'node',
                 },
                 "V2": {
                     "type": "Evaluation",
@@ -373,8 +372,7 @@ class TestDistributedAtomSpace:
                             ],
                         },
                     ],
-                    'is_link': True,
-                    'is_node': False,
+                    'atom_type': 'link',
                 },
             }
         ]


### PR DESCRIPTION
Change representation of ATOM_INFO to use atom_type = 'node' or 'link' instead of is_link and is_node.

Resolves #22 