### PR TITLE
[das-query-engine #20]  Implement a query method in DAS that expect a MeTTa expression rather than a PM query

### DIFF
--- a/hyperon_das/api.py
+++ b/hyperon_das/api.py
@@ -1,20 +1,23 @@
 import json
-from typing import Any, Dict, List, Optional, Tuple, Union
+from itertools import product
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from hyperon_das_atomdb import WILDCARD
 
 from hyperon_das.exceptions import (
     DatabaseTypeException,
     MethodNotAllowed,
+    UnexpectedQueryFormat,
     QueryParametersException,
 )
 from hyperon_das.factory import DatabaseFactory, DatabaseType, database_factory
 from hyperon_das.logger import logger
+from hyperon_das.cache import LazyQueryEvaluator, ListIterator, QueryAnswerIterator
 from hyperon_das.pattern_matcher import (
     LogicalExpression,
     PatternMatchingAnswer,
 )
-from hyperon_das.utils import QueryOutputFormat, QueryParameters
+from hyperon_das.utils import Assignment, QueryAnswer, QueryOutputFormat, QueryParameters
 
 
 class DistributedAtomSpace:
@@ -23,10 +26,10 @@ class DistributedAtomSpace:
         try:
             DatabaseType(database)
         except ValueError as e:
-            raise DatabaseTypeException(
+            self._error(DatabaseTypeException(
                 message=str(e),
                 details=f'possible values {DatabaseType.values()}',
-            )
+            ))
         self.db = database_factory(DatabaseFactory(self._db_type))
         self.pattern_black_list = []
         logger().info(
@@ -92,6 +95,40 @@ class DistributedAtomSpace:
             results.append(result)
         return results
 
+    def _error(self, exception: Exception):
+        logger().error(str(exception))
+        raise exception
+
+    def _recursive_query(
+        self,
+        query: Dict[str, Any],
+        mappings: Set[Assignment] = None,
+        extra_parameters: Optional[Dict[str, Any]] = None,
+    ) -> QueryAnswerIterator:
+        if query["atom_type"] == "node":
+            atom_handle = self.db.get_node_handle(query["type"], query["name"])
+            return ListIterator([QueryAnswer(self.db.get_atom_as_dict(atom_handle), None)])
+        elif query["atom_type"] == "link":
+            matched_targets = []
+            for target in query["targets"]:
+                if target["atom_type"] == "node" or target["atom_type"] == "link":
+                    matched = self._recursive_query(target, mappings, extra_parameters)
+                    if matched:
+                        matched_targets.append(matched)
+                elif target["atom_type"] == "variable":
+                    matched_targets.append(ListIterator([QueryAnswer(target, None)]))
+                else:
+                    self._error(UnexpectedQueryFormat(
+                        message="Query processing reached an unexpected state",
+                        details=f'link: {str(query)} link target: {str(query)}',
+                    ))
+            return LazyQueryEvaluator(query["type"], matched_targets, self, extra_parameters)
+        else:
+            self._error(UnexpectedQueryFormat(
+                message="Query processing reached an unexpected state",
+                details=f'query: {str(query)}',
+            ))
+
     def clear_database(self) -> None:
         """Clear all data"""
         return self.db.clear_database()
@@ -154,7 +191,7 @@ class DistributedAtomSpace:
             answer = self.db.get_atom_as_deep_representation(handle)
             return json.dumps(answer, sort_keys=False, indent=4)
         else:
-            raise ValueError(f"Invalid output format: '{output_format}'")
+            self._error(ValueError(f"Invalid output format: '{output_format}'"))
 
     def get_node(
         self,
@@ -219,7 +256,7 @@ class DistributedAtomSpace:
             answer = self.db.get_atom_as_deep_representation(node_handle)
             return json.dumps(answer, sort_keys=False, indent=4)
         else:
-            raise ValueError(f"Invalid output format: '{output_format}'")
+            self._error(ValueError(f"Invalid output format: '{output_format}'"))
 
     def get_nodes(
         self,
@@ -286,7 +323,7 @@ class DistributedAtomSpace:
             ]
             return json.dumps(answer, sort_keys=False, indent=4)
         else:
-            raise ValueError(f"Invalid output format: '{output_format}'")
+            self._error(ValueError(f"Invalid output format: '{output_format}'"))
 
     def get_link(
         self,
@@ -335,7 +372,7 @@ class DistributedAtomSpace:
         try:
             link_handle = self.db.get_link_handle(link_type, targets)
         except Exception as e:
-            raise e
+            self._error(e)
 
         if output_format == QueryOutputFormat.HANDLE or link_handle is None:
             return link_handle
@@ -347,7 +384,7 @@ class DistributedAtomSpace:
             )
             return json.dumps(answer, sort_keys=False, indent=4)
         else:
-            raise ValueError(f"Invalid output format: '{output_format}'")
+            self._error(ValueError(f"Invalid output format: '{output_format}'"))
 
     def get_links(
         self,
@@ -419,7 +456,7 @@ class DistributedAtomSpace:
             db_answer = self.db.get_matched_type(link_type)
         else:
             # TODO: Improve this message error. What is invalid?
-            raise ValueError("Invalid parameters")
+            self._error(ValueError("Invalid parameters"))
 
         if output_format == QueryOutputFormat.HANDLE:
             return self._to_handle_list(db_answer)
@@ -428,7 +465,7 @@ class DistributedAtomSpace:
         elif output_format == QueryOutputFormat.JSON:
             return self._to_json(db_answer)
         else:
-            raise ValueError(f"Invalid output format: '{output_format}'")
+            self.error(ValueError(f"Invalid output format: '{output_format}'"))
 
     def get_link_type(self, link_handle: str) -> str:
         """
@@ -455,10 +492,7 @@ class DistributedAtomSpace:
             return resp
         # TODO: Find out what specific exceptions might happen
         except Exception as e:
-            logger().warning(
-                f"An error occurred during the query. Detail:'{str(e)}'"
-            )
-            raise e
+            self._error(e)
 
     def get_link_targets(self, link_handle: str) -> List[str]:
         """
@@ -488,10 +522,7 @@ class DistributedAtomSpace:
             return resp
         # TODO: Find out what specific exceptions might happen
         except Exception as e:
-            logger().warning(
-                f"An error occurred during the query. Detail:'{str(e)}'"
-            )
-            raise e
+            self._error(e)
 
     def get_node_type(self, node_handle: str) -> str:
         """
@@ -516,10 +547,7 @@ class DistributedAtomSpace:
             return resp
         # TODO: Find out what specific exceptions might happen
         except Exception as e:
-            logger().warning(
-                f"An error occurred during the query. Detail:'{str(e)}'"
-            )
-            raise e
+            self._error(e)
 
     def get_node_name(self, node_handle: str) -> str:
         """
@@ -544,12 +572,82 @@ class DistributedAtomSpace:
             return resp
         # TODO: Find out what specific exceptions might happen
         except Exception as e:
-            logger().warning(
-                f"An error occurred during the query. Detail:'{str(e)}'"
-            )
-            raise e
+            self._error(e)
 
     def query(
+        self,
+        query: Dict[str, Any],
+        extra_parameters: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Perform a query on the knowledge base using a dict as input. Returns a
+        list of dicts as result.
+
+        The input dict is a link, used as a pattern to make the query.
+        Variables can be used as link targets as well as nodes. Nested links are
+        allowed as well.
+
+        Args:
+            query (Dict[str, Any]): A pattern described as a link (possibly with nested links) with
+            nodes and variables used to query the knoeledge base.
+            extra_paramaters (Dict[str, Any], optional): query optional parameters
+
+        Returns:
+            List[Dict[str, Any]]: a list of dicts with the matching subgraphs
+
+        Raises:
+            UnexpectedQueryFormat: If query resolution lead to an invalid state
+
+        Notes:
+            - No logical connectors (AND, OR, NOT) are allowed
+            - If no match is found for the query, an empty list is returned.
+
+        Example:
+
+            >>> hash_table_api.add_link({
+                "type": "Expression",
+                "targets": [
+                    {"type": "Symbol", "name": "Test"},
+                    {
+                        "type": "Expression",
+                        "targets": [
+                            {"type": "Symbol", "name": "Test"},
+                            {"type": "Symbol", "name": "2"}
+                        ]
+                    }
+                ]
+            })
+            >>> query_params = {
+                "toplevel_only": False,
+                "return_type": QueryOutputFormat.ATOM_INFO,
+            }
+            >>> q1 = {
+                "atom_type": "link",
+                "type": "Expression",
+                "targets": [
+                    {"atom_type": "variable", "name": "v1"},
+                    {
+                        "atom_type": "link",
+                        "type": "Expression",
+                        "targets": [
+                            {"atom_type": "variable", "name": "v2"},
+                            {"atom_type": "node", "type": "Symbol", "name": "2"},
+                        ]
+                    }
+                ]
+            }
+            >>> result = hash_table_api.query(q1, query_params)
+            >>> print(result)
+            [{'handle': 'dbcf1c7b610a5adea335bf08f6509978', 'type': 'Expression', 'template': ['Expression', 'Symbol', ['Expression', 'Symbol', 'Symbol']], 'targets': [{'handle': '963d66edfb77236054125e3eb866c8b5', 'type': 'Symbol', 'name': 'Test'}, {'handle': '233d9a6da7d49d4164d863569e9ab7b6', 'type': 'Expression', 'template': ['Expression', 'Symbol', 'Symbol'], 'targets': [{'handle': '963d66edfb77236054125e3eb866c8b5', 'type': 'Symbol', 'name': 'Test'}, {'handle': '9f27a331633c8bc3c49435ffabb9110e', 'type': 'Symbol', 'name': '2'}]}]}]
+        """
+        query_results = self._recursive_query(query, extra_parameters)
+        logger().debug(f"query: {query} result: {str(query_results)}")
+        answer = []
+        for result in query_results:
+            answer.append(result.grounded_atom)
+        return answer
+
+    def pattern_matcher_query(
         self,
         query: LogicalExpression,
         extra_parameters: Optional[Dict[str, Any]] = None,
@@ -656,16 +754,16 @@ class DistributedAtomSpace:
         if self._db_type == DatabaseType.RAM_ONLY.value:
             return self.db.add_node(node_params)
         else:
-            raise MethodNotAllowed(
+            self._error(MethodNotAllowed(
                 message='This method is permited only in memory database',
                 details='Instantiate the class sent the database type as `ram_only`',
-            )
+            ))
 
     def add_link(self, link_params: Dict[str, Any]) -> Dict[str, Any]:
         if self._db_type == DatabaseType.RAM_ONLY.value:
             return self.db.add_link(link_params)
         else:
-            raise MethodNotAllowed(
+            self._error(MethodNotAllowed(
                 message='This method is permited only in memory database',
                 details='Instantiate the class sent the database type as `ram_only`',
-            )
+            ))

--- a/hyperon_das/api.py
+++ b/hyperon_das/api.py
@@ -36,7 +36,7 @@ class DistributedAtomSpace:
             self._error(DatabaseTypeException(
                 message=str(e),
                 details=f'possible values {DatabaseType.values()}',
-            )
+            ))
 
         if database == DatabaseType.SERVER.value and not host:
             raise InitializeServerException(

--- a/hyperon_das/cache.py
+++ b/hyperon_das/cache.py
@@ -1,0 +1,129 @@
+from abc import ABC, abstractmethod
+from itertools import product
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from hyperon_das.utils import Assignment, QueryAnswer, QueryOutputFormat
+from hyperon_das_atomdb import WILDCARD
+
+class QueryAnswerIterator(ABC):
+
+    def __init__(self, source: Any):
+        self.source = source
+        self.current_value = None
+        self.iterator = None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if not self.source or self.iterator is None:
+            raise StopIteration
+        try:
+            self.current_value = next(self.iterator)
+        except StopIteration as exception:
+            self.current_value = None
+            raise exception
+        return self.current_value
+
+    def get(self) -> Any:
+        if not self.source or self.current_value is None:
+            raise StopIteration
+        return self.current_value
+    
+    def __str__(self):
+        return str(self.source)
+
+    @abstractmethod
+    def is_empty(self) -> bool:
+        pass
+
+class ListIterator(QueryAnswerIterator):
+
+    def __init__(self, source: List[Any]):
+        super().__init__(source)
+        if source:
+            self.iterator = iter(self.source)
+            self.current_value = source[0]
+
+    def is_empty(self) -> bool:
+        return not self.source
+
+class ProductIterator(QueryAnswerIterator):
+
+    def __init__(self, source: List[QueryAnswerIterator]):
+        super().__init__(source)
+        if not self.is_empty():
+            self.current_value = tuple([iterator.get() for iterator in source])
+            self.iterator = product(*self.source)
+
+    def is_empty(self) -> bool:
+        return any(iterator.is_empty() for iterator in self.source)
+
+class LazyQueryEvaluator(ProductIterator):
+
+    def __init__(
+        self,
+        link_type: str,
+        source: List[QueryAnswerIterator],
+        das: "DistributedAtomSpace",
+        query_parameters: Optional[Dict[str, Any]]):
+
+        super().__init__(source)
+        self.link_type = link_type
+        self.query_parameters = query_parameters
+        self.das = das
+        self.buffered_answer = None
+
+    def _replace_target_handles(self, link: Dict[str, Any]) -> Dict[str, Any]:
+        targets = []
+        for target_handle in link["targets"]:
+            atom = self.das.db.get_atom_as_dict(target_handle)
+            if atom.get("targets", None) is not None:
+                atom = self._replace_target_handles(atom)
+            targets.append(atom)
+        link["targets"] = targets
+        return link
+
+    def __next__(self):
+        if self.buffered_answer:
+            try:
+                return self.buffered_answer.__next__()
+            except StopIteration as exception:
+                self.buffered_answer = None
+        target_info = super().__next__()
+        target_handle = []
+        wildcard_flag = False
+        for query_answer_target in target_info:
+            target = query_answer_target.grounded_atom
+            if target.get("atom_type", None) == "variable":
+                target_handle.append(WILDCARD)
+                wildcard_flag = True
+            else:
+                target_handle.append(target["handle"])
+        das_query_answer = self.das.get_links(
+            self.link_type,
+            None,
+            target_handle,
+            output_format = QueryOutputFormat.ATOM_INFO)
+        lazy_query_answer = []
+        for answer in das_query_answer:
+            assignment = None
+            if wildcard_flag:
+                assignment = Assignment()
+                assignment_failed = False
+                for query_answer_target, handle in zip(target_info, answer["targets"]):
+                    target = query_answer_target.grounded_atom
+                    if target.get("atom_type", None) == "variable":
+                        if not assignment.assign(target["name"], handle):
+                            assignment_failed = True
+                    else:
+                        if not assignment.merge(query_answer_target.assignment):
+                            assignment_failed = True
+                    if not assignment_failed:
+                        break
+                if assignment_failed:
+                    continue
+                assignment.freeze()
+            
+            lazy_query_answer.append(QueryAnswer(self._replace_target_handles(answer), assignment))
+        self.buffered_answer = ListIterator(lazy_query_answer)
+        return self.buffered_answer.__next__()

--- a/hyperon_das/exceptions.py
+++ b/hyperon_das/exceptions.py
@@ -20,3 +20,11 @@ class MethodNotAllowed(BaseException):
 
 class QueryParametersException(BaseException):
     ...  # pragma no cover
+
+
+class UnexpectedQueryFormat(BaseException):
+    ...  # pragma no cover
+
+
+class InvalidAssignment(BaseException):
+    ...  # pragma no cover

--- a/hyperon_das/utils.py
+++ b/hyperon_das/utils.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Optional
+from typing import Any, Dict, Optional, Set
+from hyperon_das.exceptions import InvalidAssignment
 
 
 class QueryOutputFormat(int, Enum):
     HANDLE = auto()
     ATOM_INFO = auto()
     JSON = auto()
-
 
 @dataclass
 class QueryParameters:
@@ -17,3 +17,75 @@ class QueryParameters:
     @classmethod
     def values(cls) -> list:
         return list(cls.__dataclass_fields__.keys())
+
+class Assignment:
+
+    def __init__(self):
+        self.labels: Union[Set[str], FrozenSet] = set()
+        self.values: Union[Set[str], FrozenSet] = set()
+        self.mapping: Dict[str, str] = {}
+        self.hashcode: int = 0
+
+    def __hash__(self) -> int:
+        assert self.hashcode
+        return self.hashcode
+
+    def __eq__(self, other) -> bool:
+        assert self.hashcode and other.hashcode
+        return self.hashcode == other.hashcode
+
+    def __lt__(self, other) -> bool:
+        assert self.hashcode and other.hashcode
+        return self.hashcode < other.hashcode
+
+    def __repr__(self) -> str:
+        labels = sorted(self.labels)
+        return str([tuple([label, self.mapping[label]]) for label in sorted(self.labels)])
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def frozen(self):
+        return self.hashcode != 0
+
+    def freeze(self) -> bool:
+        if self.frozen():
+            return False
+        else:
+            self.labels = frozenset(self.labels)
+            self.values = frozenset(self.values)
+            self.hashcode = hash(frozenset(self.mapping.items()))
+            return True
+
+    def assign(
+        self,
+        label: str,
+        value: str,
+        parameters: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        if label is None or value is None or self.frozen():
+            raise InvalidAssignment(
+                message = f"Invalid assignment",
+                details = f"label = {label} value = {value} hashcode = {self.hashcode}"
+            )
+        if label in self.labels:
+            return self.mapping[label] == value
+        else:
+            if parameters and parameters['no_overload'] and value in self.values:
+                return False
+            self.labels.add(label)
+            self.values.add(value)
+            self.mapping[label] = value
+            return True
+
+    def merge(self, other: "Assignment") -> bool:
+        assert not self.frozen()
+        for label, value in other.mapping.items():
+            if not self.assign(label, value):
+                return False
+        return True
+
+@dataclass
+class QueryAnswer:
+    grounded_atom: Optional[Dict] = None
+    assignment: Optional[Assignment] = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -103,19 +103,19 @@ class TestDistributedAtomSpace:
             ]
         )
 
-        ret = das.query(
+        ret = das.pattern_matcher_query(
             and_expression, {'return_type': QueryOutputFormat.HANDLE}
         )
         assert len(ret['mapping']) == 7
         assert ret['negation'] == False
 
-        ret_atom_info = das.query(
+        ret_atom_info = das.pattern_matcher_query(
             and_expression, {'return_type': QueryOutputFormat.ATOM_INFO}
         )
         assert len(ret_atom_info['mapping']) == 7
         assert ret['negation'] == False
 
-        ret_json = das.query(
+        ret_json = das.pattern_matcher_query(
             and_expression, {'return_type': QueryOutputFormat.JSON}
         )
         assert len(json.loads(ret_json['mapping'])) == 7
@@ -124,7 +124,7 @@ class TestDistributedAtomSpace:
         not_expression = Not(
             Link("Inheritance", ordered=True, targets=[V1, V2])
         )
-        ret = das.query(not_expression)
+        ret = das.pattern_matcher_query(not_expression)
         assert ret['negation'] == True
 
     # TODO: Adjust Mock class
@@ -135,7 +135,7 @@ class TestDistributedAtomSpace:
             targets=[Variable('V1'), Variable('V2')],
         )
 
-        ret = das.query(
+        ret = das.pattern_matcher_query(
             expression,
             {
                 'toplevel_only': True,
@@ -182,7 +182,7 @@ class TestDistributedAtomSpace:
             targets=[Variable('V1'), Variable('V2')],
         )
         with pytest.raises(QueryParametersException) as exc_info:
-            das.query(
+            das.pattern_matcher_query(
                 expression,
                 {
                     'parameter_fake': True,
@@ -396,3 +396,42 @@ class TestDistributedAtomSpace:
         #     set([nodes.human, nodes.ent]),
         #     [nodes.human, nodes.mammal],
         # ])
+
+
+    #def test_nested_pattern(self, das: DistributedAtomSpace):
+    #    das.add_link({
+    #        "type": "Expression",
+    #        "targets": [
+    #            {"type": "Symbol", "name": "Test"},
+    #            {
+    #                "type": "Expression",
+    #                "targets": [
+    #                    {"type": "Symbol", "name": "Test"},
+    #                    {"type": "Symbol", "name": "2"}
+    #                ]
+    #            }
+    #        ]
+    #    })
+    #    query_params = {
+    #        "toplevel_only": False,
+    #        "return_type": QueryOutputFormat.ATOM_INFO,
+    #    }
+    #    q1 = {
+    #        "atom_type": "link",
+    #        "type": "Expression",
+    #        "targets": [
+    #            {"atom_type": "variable", "name": "v1"},
+    #            {
+    #                "atom_type": "link",
+    #                "type": "Expression",
+    #                "targets": [
+    #                    {"atom_type": "variable", "name": "v2"},
+    #                    {"atom_type": "node", "type": "Symbol", "name": "2"},
+    #                ]
+    #            }
+    #                
+    #        ]
+    #    }
+    #    answer = das.query(q1, query_params)
+    #    assert len(answer) == 1
+    #    assert answer[0]["handle"] == "dbcf1c7b610a5adea335bf08f6509978"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,118 @@
+import pytest
+from hyperon_das.cache import ListIterator, ProductIterator
+from hyperon_das.utils import Assignment
+
+
+class TestCache:
+
+    def test_list_iterator(self):
+
+        iterator = ListIterator(None)
+        for element in iterator:
+            assert False
+
+        iterator = ListIterator([])
+        for element in iterator:
+            assert False
+
+        iterator = ListIterator([
+            ([{"id": 1}], Assignment()),
+        ])
+        expected = [1]
+        count = 0
+        for element in iterator:
+            assert element[0][0]["id"] == expected[count]
+            count += 1
+        assert count == len(expected)
+
+        iterator = ListIterator([
+            ([{"id": 1}], Assignment()),
+            ([{"id": 2}], Assignment()),
+        ])
+        expected = [1, 2]
+        count = 0
+        for element in iterator:
+            assert element[0][0]["id"] == expected[count]
+            count += 1
+        assert count == len(expected)
+
+        iterator = ListIterator([
+            ([{"id": 1}], Assignment()),
+            ([{"id": 2}], Assignment()),
+            ([{"id": 2}], Assignment()),
+        ])
+        expected = [1, 2, 2]
+        count = 0
+        for element in iterator:
+            assert element[0][0]["id"] == expected[count]
+            count += 1
+        assert count == len(expected)
+
+        iterator = ListIterator([([{"id": 1}], Assignment()),])
+        assert not iterator.is_empty()
+        iterator = ListIterator([None])
+        assert not iterator.is_empty()
+        iterator = ListIterator([])
+        assert iterator.is_empty()
+        iterator = ListIterator(None)
+        assert iterator.is_empty()
+
+    def test_product_iterator(self):
+
+        ln = None
+        l0 = []
+        l1 = [1, 2, 3]
+        l2 = [4]
+        l3 = [5, 6]
+        l4 = [7, 8]
+
+        li1 = ListIterator(l1)
+        li3 = ListIterator(l3)
+        iterator = ProductIterator([li1, li3])
+        assert not iterator.is_empty()
+        assert iterator.get() == (1, 5)
+        expected = [(1, 5), (1, 6), (2, 5), (2, 6), (3, 5), (3, 6)]
+        count = 0
+        for element in iterator:
+            assert element == expected[count]
+            assert iterator.get() == expected[count]
+            count += 1
+        assert not iterator.is_empty()
+        with pytest.raises(StopIteration):
+            assert iterator.get()
+
+        li3 = ListIterator(l3)
+        li4 = ListIterator(l4)
+        iterator = ProductIterator([li3, li4])
+        expected = [(5, 7), (5, 8), (6, 7), (6, 8)]
+        count = 0
+        for element in iterator:
+            assert element == expected[count]
+            count += 1
+        assert not iterator.is_empty()
+
+        li1 = ListIterator(l1)
+        li2 = ListIterator(l2)
+        li3 = ListIterator(l3)
+        iterator = ProductIterator([li1, li2, li3])
+        expected = [(1, 4, 5), (1, 4, 6), (2, 4, 5), (2, 4, 6), (3, 4, 5), (3, 4, 6)]
+        count = 0
+        for element in iterator:
+            assert element == expected[count]
+            count += 1
+        with pytest.raises(StopIteration):
+            assert iterator.get()
+
+        for arg in [[ln, l1], [ln, l1, l2], [ln]]:
+            iterator = ProductIterator([ListIterator(v) for v in arg])
+            assert iterator.is_empty()
+            for element in iterator:
+                assert False
+            assert iterator.is_empty()
+
+        for arg in [[l0, l1], [l0, l1, l2], [l0]]:
+            iterator = ProductIterator([ListIterator(v) for v in arg])
+            assert iterator.is_empty()
+            for element in iterator:
+                assert False
+            assert iterator.is_empty()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,129 @@
+import pytest
+from hyperon_das.utils import Assignment
+from hyperon_das.exceptions import InvalidAssignment
+
+
+def _build_assignment(mappings):
+    answer = Assignment()
+    for label, value in mappings:
+        answer.assign(label, value)
+    return answer
+        
+def _check_merge(l1, l2, expected_list, flag):
+    a1 = _build_assignment(l1)
+    a2 = _build_assignment(l2)
+    expected = _build_assignment(expected_list)
+    assert a1.merge(a2) == flag
+    if flag:
+        a1.freeze()
+        expected.freeze()
+        assert a1.__eq__(expected)
+
+class TestAssignment:
+
+    def test_basics(self):
+
+        va1 = Assignment()
+        assert va1.assign("v1", "1")
+        assert va1.assign("v2", "2")
+        with pytest.raises(InvalidAssignment):
+            va1.assign("v3", None)
+        with pytest.raises(InvalidAssignment):
+            va1.assign(None, "3")
+        assert not va1.assign("v3", "2", parameters={"no_overload": True})
+        assert va1.assign("v3", "2", parameters={"no_overload": False})
+        assert va1.assign("v3", "2")
+        assert va1.hashcode == 0
+        assert va1.freeze()
+        assert va1.hashcode != 0
+        with pytest.raises(InvalidAssignment):
+            assert va1.assign("v4", "4")
+        a1 = _build_assignment([("v1", "1"), ("v2", "2")])
+        a2 = _build_assignment([("v2", "2"), ("v1", "1")])
+        a3 = _build_assignment([("v1", "1"), ("v2", "1")])
+        with pytest.raises(AssertionError):
+            a1.__eq__(a2)
+        assert a1.freeze()
+        assert a2.freeze()
+        assert a1.__eq__(a2)
+        assert a2.__eq__(a1)
+        assert a3.freeze()
+        assert not a1.__eq__(a3)
+        assert not a3.__eq__(a1)
+
+    def test_assignment_sets(self):
+
+        va1 = Assignment()
+        va2 = Assignment()
+        va3 = Assignment()
+        va1.assign("v1", "1")
+        va1.assign("v2", "2")
+        va2.assign("v2", "2")
+        va2.assign("v1", "1")
+        va3.assign("v1", "2")
+        va3.assign("v2", "1")
+
+        with pytest.raises(Exception):
+            s1 = set([va1, va2])
+        with pytest.raises(Exception):
+            s2 = set([va1, va3])
+
+        va1.freeze()
+        va2.freeze()
+        va3.freeze()
+        s1 = set([va1, va2])
+        s2 = set([va1, va3])
+        assert len(s1) == 1
+        assert len(s2) == 2
+        assert va1 in s1 and va2 in s1 and va3 not in s1
+        assert va1 in s2 and va2 in s2 and va3 in s2
+        
+    def test_merge(self):
+
+        _check_merge(
+            [("v1", "1"), ("v2", "2")],
+            [("v3", "3"), ("v4", "4")],
+            [("v1", "1"), ("v2", "2"), ("v3", "3"), ("v4", "4")],
+            True)
+
+        _check_merge(
+            [("v1", "1"), ("v2", "2")],
+            [("v1", "1"), ("v5", "5")],
+            [("v1", "1"), ("v2", "2"), ("v5", "5")],
+            True)
+
+        _check_merge(
+            [("v1", "1"), ("v2", "2")],
+            [("v1", "2"), ("v5", "5")],
+            [],
+            False)
+
+        _check_merge(
+            [("v1", "1"), ("v2", "2")],
+            [("v1", "1"), ("v2", "2")],
+            [("v1", "1"), ("v2", "2")],
+            True)
+
+        _check_merge(
+            [("v1", "1"), ("v2", "2")],
+            [("v1", "2"), ("v2", "1")],
+            [],
+            False)
+        
+        _check_merge(
+            [("v1", "1"), ("v2", "2")],
+            [],
+            [("v1", "1"), ("v2", "2")],
+            True)
+
+        _check_merge(
+            [],
+            [("v1", "1"), ("v2", "2")],
+            [("v1", "1"), ("v2", "2")],
+            True)
+
+        a1 = _build_assignment([("v1", "1")])
+        a2 = _build_assignment([("v1", "1")])
+        assert a1.freeze()
+        with pytest.raises(AssertionError):
+            a1.merge(a2)


### PR DESCRIPTION
Resolves #20 

* renamed query() to pattern_matcher_query()
* a new method query() was implemented with a different API. This new method expects a dict describing the query instead of a LogicalExpression object. The method also return a dict describing the subgraphs that matches the query.

This new method is supposed to be used in the integration of DAS with the MeTTa interpreter.

This is an example of how top use it:

```
        q1 = {
            "atom_type": "link",
            "type": "Expression",
            "targets": [
                {"atom_type": "variable", "name": "v1"},
                {
                    "atom_type": "link",
                    "type": "Expression",
                    "targets": [
                        {"atom_type": "variable", "name": "v2"},
                        {"atom_type": "node", "type": "Symbol", "name": "2"},
                    ]
                }

            ]
        }
        answer = hash_table_api.query(q1, query_params)
```

The return is a list of dicts with the subgraphs that matched the query. For example:

```
[
    {
        'handle': 'dbcf1c7b610a5adea335bf08f6509978', 
        'type': 'Expression', 
        'template': ['Expression', 'Symbol', ['Expression', 'Symbol', 'Symbol']], 
        'targets': [
            {'handle': '963d66edfb77236054125e3eb866c8b5', 'type': 'Symbol', 'name': 'Test'}, 
            {
                'handle': '233d9a6da7d49d4164d863569e9ab7b6', 
                'type': 'Expression', 
                'template': ['Expression', 'Symbol', 'Symbol'], 
                'targets': [
                    {'handle': '963d66edfb77236054125e3eb866c8b5', 'type': 'Symbol', 'name': 'Test'}, 
                    {'handle': '9f27a331633c8bc3c49435ffabb9110e', 'type': 'Symbol', 'name': '2'}
                ]
            }
        ]
    }
]
```