### PR TITLE
[HOTFIX] Add empty implementation of reindex()

### DIFF
--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -312,6 +312,9 @@ class DatabaseMock(AtomDB):
     def get_atom_type(self, handle: str) -> str:
         pass
 
+    def reindex(self, not_used):
+        pass
+
 
 class DatabaseAnimals(DatabaseMock):
     def __init__(self):


### PR DESCRIPTION
Minor fix after PR https://github.com/singnet/das-atom-db/pull/87 to make the code compliant with the abstract definition of reindex() in AtomDB.