### PR TITLE
[#281] Reformatting code, renaming some exception classes, adding docstrings to `QueryEngine(ABC)`

### DIFF
--- a/hyperon_das/cache/iterators.py
+++ b/hyperon_das/cache/iterators.py
@@ -33,7 +33,7 @@ class QueryAnswerIterator(ABC):
 
     @abstractmethod
     def is_empty(self) -> bool:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     def get(self) -> Any:
         if not self.source or self.current_value is None:

--- a/hyperon_das/cache/iterators.py
+++ b/hyperon_das/cache/iterators.py
@@ -33,7 +33,13 @@ class QueryAnswerIterator(ABC):
 
     @abstractmethod
     def is_empty(self) -> bool:
-        raise NotImplementedError
+        """
+        Determines if the iterator has no more elements to iterate over.
+
+        Returns:
+            bool: True if the iterator is empty and has no more elements to yield, False otherwise.
+        """
+        ...
 
     def get(self) -> Any:
         if not self.source or self.current_value is None:

--- a/hyperon_das/client.py
+++ b/hyperon_das/client.py
@@ -5,7 +5,12 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from hyperon_das_atomdb import AtomDoesNotExist, LinkDoesNotExist, NodeDoesNotExist
 from requests import exceptions, sessions
 
-from hyperon_das.exceptions import ConnectionError, HTTPError, RequestError, TimeoutError
+from hyperon_das.exceptions import (
+    FunctionsConnectionError,
+    FunctionsTimeoutError,
+    HTTPError,
+    RequestError,
+)
 from hyperon_das.logger import logger
 from hyperon_das.type_alias import Query
 from hyperon_das.utils import connect_to_server, das_error, deserialize, serialize
@@ -45,14 +50,14 @@ class FunctionsClient:
                 )
         except exceptions.ConnectionError as e:
             das_error(
-                ConnectionError(
+                FunctionsConnectionError(
                     message=f"Connection error for URL: '{self.url}' with payload: '{payload}'",
                     details=str(e),
                 )
             )
         except exceptions.Timeout as e:
             das_error(
-                TimeoutError(
+                FunctionsTimeoutError(
                     message=f"Request timed out for URL: '{self.url}' with payload: '{payload}'",
                     details=str(e),
                 )

--- a/hyperon_das/decorators.py
+++ b/hyperon_das/decorators.py
@@ -3,7 +3,7 @@ from functools import wraps
 from http import HTTPStatus  # noqa: F401
 from typing import Callable
 
-from hyperon_das.exceptions import ConnectionError
+from hyperon_das.exceptions import RetryConnectionError
 from hyperon_das.logger import logger
 
 
@@ -26,7 +26,7 @@ def retry(attempts: int, timeout_seconds: int):
                         )
                         return response
                 except Exception as e:
-                    raise ConnectionError(
+                    raise RetryConnectionError(
                         message="An error occurs while connecting to the server",
                         details=str(e),
                     )
@@ -42,7 +42,7 @@ def retry(attempts: int, timeout_seconds: int):
                 + f' - attempts:{retry_count} - time_attempted: {timer_count}'
             )
             logger().info(message)
-            raise ConnectionError(message)
+            raise RetryConnectionError(message)
 
         return wrapper
 

--- a/hyperon_das/exceptions.py
+++ b/hyperon_das/exceptions.py
@@ -1,10 +1,8 @@
 from typing import Union
 
 
-class BaseException(Exception):
-    """
-    Base class to exceptions
-    """
+class QueryEngineBaseException(Exception):
+    """Base class to exceptions in this module."""
 
     def __init__(self, message: str, details: str = ""):
         self.message = message
@@ -13,47 +11,61 @@ class BaseException(Exception):
         super().__init__(self.message, self.details)
 
 
-class QueryParametersException(BaseException):
-    ...  # pragma no cover
+class QueryParametersException(QueryEngineBaseException):
+    """Exception raised for errors in the parameters of a query."""
 
 
-class UnexpectedQueryFormat(BaseException):
-    ...  # pragma no cover
+class UnexpectedQueryFormat(QueryEngineBaseException):
+    """Exception raised for errors in the format of a query."""
 
 
-class InvalidAssignment(BaseException):
-    ...  # pragma no cover
+class InvalidAssignment(QueryEngineBaseException):
+    """Exception raised for invalid assignments."""
 
 
-class ConnectionError(BaseException):
-    ...  # pragma no cover
+class _ConnectionError(QueryEngineBaseException):
+    """Exception raised for connection errors."""
 
 
-class TimeoutError(BaseException):
-    ...  # pragma no cover
+class RetryConnectionError(_ConnectionError):
+    """Exception raised for retry connection errors."""
 
 
-class HTTPError(BaseException):
+class FunctionsConnectionError(_ConnectionError):
+    """Exception raised for functions connection errors."""
+
+
+class _TimeoutError(QueryEngineBaseException):
+    """Exception raised for timeout errors."""
+
+
+class FunctionsTimeoutError(_TimeoutError):
+    """Exception raised for functions timeout errors."""
+
+
+class HTTPError(QueryEngineBaseException):
+    """Exception raised for HTTP errors."""
+
     def __init__(self, message: str, details: str = "", status_code: Union[int, None] = None):
         super().__init__(message, details)
         self.status_code = status_code
 
 
-class RequestError(BaseException):
-    ...  # pragma no cover
+class RequestError(QueryEngineBaseException):
+    """Exception raised for request errors."""
 
 
-class RetryException(BaseException):
-    ...  # pragma no cover
+class RetryException(QueryEngineBaseException):
+    """Exception raised for retry errors."""
 
 
-class InvalidDASParameters(BaseException):
-    ...  # pragma no cover
+class InvalidDASParameters(QueryEngineBaseException):
+    """Exception raised for invalid DAS parameters."""
 
 
-class InvalidQueryEngine(BaseException):
-    ...  # pragma no cover
+class InvalidQueryEngine(QueryEngineBaseException):
+    """Exception raised for invalid query engines."""
 
 
-class GetTraversalCursorException(BaseException):
-    ...  # pragma no cover
+class GetTraversalCursorException(QueryEngineBaseException):
+    """Exception raised for errors in getting traversal cursor."""

--- a/hyperon_das/grpc/common_pb2.pyi
+++ b/hyperon_das/grpc/common_pb2.pyi
@@ -37,6 +37,7 @@ class HandleCount(_message.Message):
         key: str
         value: int
         def __init__(self, key: _Optional[str] = ..., value: _Optional[int] = ...) -> None: ...
+
     HANDLE_COUNT_FIELD_NUMBER: _ClassVar[int]
     handle_count: _containers.ScalarMap[str, int]
     def __init__(self, handle_count: _Optional[_Mapping[str, int]] = ...) -> None: ...

--- a/hyperon_das/query_engines.py
+++ b/hyperon_das/query_engines.py
@@ -32,47 +32,193 @@ from hyperon_das.utils import Assignment, QueryAnswer, das_error
 class QueryEngine(ABC):
     @abstractmethod
     def get_atom(self, handle: str) -> Union[Dict[str, Any], None]:
-        raise NotImplementedError
+        """
+        Retrieves an atom from the database using its unique handle.
+
+        This method searches the database for an atom with the specified handle. If found, it returns
+        the atom's data as a dictionary. If no atom with the given handle exists, it returns None.
+
+        Args:
+            handle (str): The unique handle of the atom to retrieve.
+
+        Returns:
+            Union[Dict[str, Any], None]: A dictionary containing the atom's data if found, otherwise None.
+        """
+        ...
 
     @abstractmethod
     def get_node(self, node_type: str, node_name: str) -> Union[Dict[str, Any], None]:
-        raise NotImplementedError
+        """
+        Retrieves a node of a specified type and name.
+
+        This method searches for a node that matches the specified type and name. If such a node exists,
+        it returns the node's data; otherwise, it returns None.
+
+        Args:
+            node_type (str): The type of the node to retrieve.
+            node_name (str): The name of the node to retrieve.
+
+        Returns:
+            Union[Dict[str, Any], None]: A dictionary containing the node's data if found, otherwise None.
+        """
+        ...
 
     @abstractmethod
     def get_link(self, link_type: str, targets: List[str]) -> Union[Dict[str, Any], None]:
-        raise NotImplementedError
+        """
+        Retrieves a link of a specified type that connects to the given targets.
+
+        This method searches for a link that matches the specified link type and is connected to
+        the provided target nodes. The targets are specified by their handles. If such a link exists,
+        it returns the link's data; otherwise, it returns None.
+
+        Args:
+            link_type (str): The type of the link to retrieve.
+            targets (List[str]): A list of handles for the target nodes that the link connects to.
+
+        Returns:
+            Union[Dict[str, Any], None]: A dictionary containing the link's data if found, otherwise None.
+        """
+        ...
 
     @abstractmethod
     def get_links(
         self, link_type: str, target_types: List[str] = None, link_targets: List[str] = None
     ) -> Union[List[str], List[Dict]]:
-        raise NotImplementedError
+        """
+        Retrieves links of a specified type, optionally filtered by target types or specific targets.
+
+        This method can be used to fetch links that match a given link type. Additionally, it allows
+        for filtering based on the types of the targets (target_types) or the specific targets
+        themselves (link_targets). If both target_types and link_targets are provided, the method
+        filters using both criteria.
+
+        Args:
+            link_type (str): The type of links to retrieve. This parameter is mandatory.
+            target_types (List[str], optional): A list of target types to filter the links by. If
+                provided, only links that have targets of these types will be returned. Defaults to None.
+            link_targets (List[str], optional): A list of specific targets to filter the links by. If
+                provided, only links that have these specific targets will be returned. Defaults to None.
+
+        Returns:
+            Union[List[str], List[Dict]]: A list of links that match the criteria. The list contains
+            either strings (handles of the links) or dictionaries (the link objects themselves),
+            depending on the implementation details of the subclass.
+        """
+        ...
 
     @abstractmethod
     def get_incoming_links(
         self, atom_handle: str, **kwargs
     ) -> List[Union[dict, str, Tuple[dict, List[dict]]]]:
-        raise NotImplementedError
+        """
+        Retrieves incoming links for a specified atom handle, with optional filtering parameters.
+
+        This method fetches all links pointing to the specified atom, identified by its handle. It
+        can return a simple list of links, a list of dictionaries with link details, or a list of
+        tuples containing link details and their respective target atoms' details, depending on the
+        implementation and the provided keyword arguments.
+
+        Args:
+            atom_handle (str): The unique handle of the atom for which incoming links are to be
+                               retrieved.
+
+        Keyword Args:
+            **kwargs: Arbitrary keyword arguments for filtering or specifying the format of the
+                      returned data. The exact options available depend on the implementation.
+
+        Returns:
+            List[Union[dict, str, Tuple[dict, List[dict]]]]: A list containing the incoming links. The
+            format of the list's elements can vary based on the provided keyword arguments and the
+            implementation details.
+        """
+        ...
 
     @abstractmethod
     def query(
         self, query: Query, parameters: Optional[Dict[str, Any]] = {}
     ) -> Union[Iterator[QueryAnswer], List[QueryAnswer]]:
+        """
+        Executes a query against the database and returns the results.
+
+        This method processes a given query, applying any provided parameters to modify its behavior
+        or filter its results. Depending on the 'no_iterator' parameter within 'parameters', this
+        method may return either a list of QueryAnswer objects or an iterator over such objects.
+
+        Args:
+            query (Query): The query to be executed. This is typically a structured query that
+                           specifies what data to retrieve or what operations to perform.
+            parameters (Optional[Dict[str, Any]]): A dictionary of parameters that can modify the
+                           query execution or its results. For example, 'no_iterator' can be set to
+                           True to return a list instead of an iterator.
+
+        Returns:
+            Union[Iterator[QueryAnswer], List[QueryAnswer]]: Depending on the 'no_iterator' parameter,
+            returns either an iterator over QueryAnswer objects or a list of QueryAnswer objects.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def custom_query(
         self, index_id: str, query: Query, **kwargs
     ) -> Union[Iterator, List[Dict[str, Any]]]:
-        raise NotImplementedError
+        """
+        Executes a custom query based on a specific index ID and query parameters.
+
+        This method allows for executing more complex or specific queries that are not covered
+        by the standard query methods. It can return either a list of dictionaries containing
+        the query results or an iterator over such dictionaries, depending on the 'no_iterator'
+        parameter in kwargs.
+
+        Args:
+            index_id (str): The ID of the index to query against.
+            query (Query): The query to be executed. This is typically a structured query that
+                           specifies what data to retrieve or what operations to perform.
+
+        Keyword Args:
+            **kwargs: Arbitrary keyword arguments that can modify the query execution or its
+                      results. For example, 'no_iterator' can be set to True to return a list
+                      instead of an iterator. Other options depend on the implementation.
+
+        Returns:
+            Union[Iterator, List[Dict[str, Any]]]: Depending on the 'no_iterator' parameter, returns
+            either an iterator over dictionaries containing the query results or a list of such
+            dictionaries.
+        """
+        ...
 
     @abstractmethod
     def count_atoms(self) -> Tuple[int, int]:
-        raise NotImplementedError
+        """
+        Counts the total number of atoms in the database.
+
+        This method aggregates the count of all atoms stored within the database, providing a
+        comprehensive overview of the total number of atoms. It returns a tuple where the first
+        element represents the count of node atoms, and the second element represents the count of
+        link atoms.
+
+        Returns:
+            Tuple[int, int]: A tuple containing two integers, where the first integer is the count of
+            node atoms and the second is the count of link atoms.
+        """
+        ...
 
     @abstractmethod
     def reindex(self, pattern_index_templates: Optional[Dict[str, Dict[str, Any]]]):
-        raise NotImplementedError
+        """
+        Reindexes the database based on the provided pattern index templates.
+
+        This method allows for the reindexing of the database to optimize query performance based
+        on specific patterns defined in the index templates. It can be used to create or update
+        indexes for more efficient data retrieval.
+
+        Args:
+            pattern_index_templates (Optional[Dict[str, Dict[str, Any]]]): A dictionary where each
+                key represents an index name, and its value is another dictionary specifying the
+                index pattern and additional parameters. If None, the method may perform a default
+                reindexing operation, depending on the implementation.
+        """
+        ...
 
     @abstractmethod
     def create_field_index(
@@ -83,7 +229,27 @@ class QueryEngine(ABC):
         composite_type: Optional[List[Any]] = None,
         index_type: Optional[str] = None,
     ) -> str:
-        raise NotImplementedError
+        """
+        Creates an index for a specified atom type and fields, with optional parameters for further
+        customization.
+
+        This method facilitates the creation of indexes on atoms to improve query performance. It
+        supports indexing on various atom types and allows for the specification of named types,
+        composite types, and the index type itself for more advanced indexing strategies.
+
+        Args:
+            atom_type (str): The type of atom to index.
+            fields (List[str]): The list of fields of the atom to be included in the index.
+            named_type (Optional[str]): The named type of the atom, if applicable. Defaults to None.
+            composite_type (Optional[List[Any]]): A list specifying the composite type of the atom,
+                if applicable. Defaults to None.
+            index_type (Optional[str]): The type of index to create. This can be used to specify
+                different indexing strategies or algorithms. Defaults to None.
+
+        Returns:
+            str: A string identifier for the created index.
+        """
+        ...
 
     @abstractmethod
     def fetch(
@@ -93,29 +259,128 @@ class QueryEngine(ABC):
         port: Optional[int] = None,
         **kwargs,
     ) -> Any:
-        raise NotImplementedError
+        """
+        Fetches data based on a given query, optionally targeting a specific host and port.
+
+        This method is designed to execute a query and retrieve data from either a local or remote
+        backend, depending on the provided host and port. If no host or port is specified, the method
+        defaults to using the local backend. Additional keyword arguments can be provided to further
+        customize the query execution or the data retrieval process.
+
+        Args:
+            query (Query): The query to be executed. This is typically a structured query that
+                           specifies what data to retrieve or what operations to perform.
+            host (Optional[str]): The host of the remote backend to query. If None, the local backend
+                                  is used. Defaults to None.
+            port (Optional[int]): The port of the remote backend to query. This parameter is ignored
+                                  if the host is None. Defaults to None.
+
+        Keyword Args:
+            **kwargs: Arbitrary keyword arguments that can modify the query execution or its results.
+                      These options depend on the implementation of the backend.
+
+        Returns:
+            Any: The result of the query execution. The exact type and structure of the result depend
+                 on the implementation of the backend and the nature of the query.
+        """
+        ...
 
     @abstractmethod
     def create_context(self, name: str, queries: Optional[List[Query]]) -> Context:
-        raise NotImplementedError
+        """
+        Creates a new context with a specified name and an optional list of queries.
+
+        This method initializes a new context object that can be used to manage and execute a
+        collection of queries within a defined scope. The context can encapsulate a specific
+        computational or data retrieval task, grouping related queries for efficient management
+        and execution.
+
+        Args:
+            name (str): The name of the context. This should be unique within the scope of the
+                        application or dataset.
+            queries (Optional[List[Query]]): A list of queries to be associated with the context.
+                                             These queries can be executed within the context's
+                                             scope. Defaults to None, indicating no initial queries.
+
+        Returns:
+            Context: An instance of the Context class, initialized with the specified name and
+                     queries.
+        """
+        ...
 
     @abstractmethod
     def commit(self, **kwargs) -> None:
-        raise NotImplementedError
+        """
+        Commits changes to the database.
+
+        This method is responsible for committing any pending changes to the database. Depending on the
+        implementation, this could involve flushing a local buffer to a remote database, or directly
+        committing changes to a local database. The behavior can be modified by passing specific keyword
+        arguments.
+
+        Keyword Args:
+            **kwargs: Arbitrary keyword arguments that can influence the commit operation. The exact
+                      options available depend on the implementation. For example, a 'buffer' keyword
+                      could be used to specify a particular set of changes to commit.
+        """
+        ...
 
     @abstractmethod
     def get_atoms_by_field(self, query: Query) -> List[str]:
-        raise NotImplementedError
+        """
+        Retrieves a list of atom handles based on a specified field query.
+
+        This method executes a query that filters atoms by specific field values. It returns a list
+        of atom handles that match the query criteria. The query should specify the field and value(s)
+        to filter by.
+
+        Args:
+            query (Query): The query specifying the field and value(s) to filter atoms by.
+
+        Returns:
+            List[str]: A list of atom handles that match the query criteria.
+        """
+        ...
 
     @abstractmethod
     def get_atoms_by_text_field(
         self, text_value: str, field: Optional[str] = None, text_index_id: Optional[str] = None
     ) -> List[str]:
-        raise NotImplementedError
+        """
+        Retrieves a list of atom handles based on a text field value, with optional field and index ID.
+
+        This method is designed to search for atoms where a specified text field matches the given
+        text value. It allows for an optional field specification and the use of a specific text index
+        ID for more efficient querying.
+
+        Args:
+            text_value (str): The text value to search for within the specified field.
+            field (Optional[str]): The name of the field to search. If None, a default or all-encompassing
+                                   text search may be performed, depending on the implementation.
+            text_index_id (Optional[str]): The ID of the text index to use for the search. This can
+                                           optimize the search process if provided. Defaults to None.
+
+        Returns:
+            List[str]: A list of atom handles that match the search criteria.
+        """
+        ...
 
     @abstractmethod
     def get_node_by_name_starting_with(self, node_type: str, startswith: str) -> List[str]:
-        raise NotImplementedError
+        """
+        Retrieves a list of node handles where the node name starts with a specified string.
+
+        This method searches for nodes of a specific type whose names begin with the given 'startswith'
+        string. It returns a list of handles for the nodes that match these criteria.
+
+        Args:
+            node_type (str): The type of the nodes to search for.
+            startswith (str): The initial string of the node names to match.
+
+        Returns:
+            List[str]: A list of handles for the nodes that match the search criteria.
+        """
+        ...
 
 
 class LocalQueryEngine(QueryEngine):

--- a/hyperon_das/query_engines.py
+++ b/hyperon_das/query_engines.py
@@ -32,47 +32,47 @@ from hyperon_das.utils import Assignment, QueryAnswer, das_error
 class QueryEngine(ABC):
     @abstractmethod
     def get_atom(self, handle: str) -> Union[Dict[str, Any], None]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def get_node(self, node_type: str, node_name: str) -> Union[Dict[str, Any], None]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def get_link(self, link_type: str, targets: List[str]) -> Union[Dict[str, Any], None]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def get_links(
         self, link_type: str, target_types: List[str] = None, link_targets: List[str] = None
     ) -> Union[List[str], List[Dict]]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def get_incoming_links(
         self, atom_handle: str, **kwargs
     ) -> List[Union[dict, str, Tuple[dict, List[dict]]]]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def query(
         self, query: Query, parameters: Optional[Dict[str, Any]] = {}
     ) -> Union[Iterator[QueryAnswer], List[QueryAnswer]]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def custom_query(
         self, index_id: str, query: Query, **kwargs
     ) -> Union[Iterator, List[Dict[str, Any]]]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def count_atoms(self) -> Tuple[int, int]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def reindex(self, pattern_index_templates: Optional[Dict[str, Dict[str, Any]]]):
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def create_field_index(
@@ -83,7 +83,7 @@ class QueryEngine(ABC):
         composite_type: Optional[List[Any]] = None,
         index_type: Optional[str] = None,
     ) -> str:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def fetch(
@@ -93,29 +93,29 @@ class QueryEngine(ABC):
         port: Optional[int] = None,
         **kwargs,
     ) -> Any:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def create_context(self, name: str, queries: Optional[List[Query]]) -> Context:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def commit(self, **kwargs) -> None:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def get_atoms_by_field(self, query: Query) -> List[str]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def get_atoms_by_text_field(
         self, text_value: str, field: Optional[str] = None, text_index_id: Optional[str] = None
     ) -> List[str]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
     @abstractmethod
     def get_node_by_name_starting_with(self, node_type: str, startswith: str) -> List[str]:
-        ...  # pragma no cover
+        raise NotImplementedError
 
 
 class LocalQueryEngine(QueryEngine):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -5,7 +5,7 @@ import pytest
 from requests import exceptions
 
 from hyperon_das.client import FunctionsClient
-from hyperon_das.exceptions import ConnectionError, RequestError, TimeoutError
+from hyperon_das.exceptions import FunctionsConnectionError, FunctionsTimeoutError, RequestError
 from hyperon_das.utils import serialize
 
 
@@ -399,7 +399,7 @@ class TestFunctionsClient:
 
         payload = {"action": "get_atom", "input": {"handle": "123"}}
 
-        with pytest.raises(ConnectionError):
+        with pytest.raises(FunctionsConnectionError):
             client._send_request(payload)
 
     def test_send_request_timeout_error(self, mock_request, client):
@@ -407,7 +407,7 @@ class TestFunctionsClient:
 
         payload = {"action": "get_atom", "input": {"handle": "123"}}
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises(FunctionsTimeoutError):
             client._send_request(payload)
 
     def test_send_request_request_exception(self, mock_request, client):

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from hyperon_das.decorators import retry
-from hyperon_das.exceptions import ConnectionError
+from hyperon_das.exceptions import RetryConnectionError
 
 logger_mock = Mock()
 
@@ -25,5 +25,7 @@ def test_retry_exception_raised(logger_mock):
     def exception_function():
         raise ValueError("Simulated exception")
 
-    with pytest.raises(ConnectionError, match='An error occurs while connecting to the server'):
+    with pytest.raises(
+        RetryConnectionError, match='An error occurs while connecting to the server'
+    ):
         exception_function()


### PR DESCRIPTION
First round of #281 

1. Applied `black` formatting.
2. Renamed some exception classes to avoid overriding Python's built-in exceptions.
3. Added docstrings to `QueryEngine(ABC)`.

