### PR TITLE
[#226] Add optional parameters to count_atoms

### DIFF
--- a/hyperon_das/client.py
+++ b/hyperon_das/client.py
@@ -171,7 +171,7 @@ class FunctionsClient:
                 raise Exception("Your query couldn't be processed because Atom nonexistent", str(e))
             raise e
 
-    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
         payload = {
             'action': 'count_atoms',
             'input': {'parameters': parameters},

--- a/hyperon_das/client.py
+++ b/hyperon_das/client.py
@@ -171,10 +171,10 @@ class FunctionsClient:
                 raise Exception("Your query couldn't be processed because Atom nonexistent", str(e))
             raise e
 
-    def count_atoms(self) -> Tuple[int, int]:
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
         payload = {
             'action': 'count_atoms',
-            'input': {},
+            'input': {'parameters': parameters},
         }
         return self._send_request(payload)
 

--- a/hyperon_das/client.py
+++ b/hyperon_das/client.py
@@ -233,7 +233,11 @@ class FunctionsClient:
     def custom_query(self, index_id: str, query: Query, **kwargs) -> List[Dict[str, Any]]:
         payload = {
             'action': 'custom_query',
-            'input': {'index_id': index_id, 'query': query, 'kwargs': kwargs},
+            'input': {
+                'index_id': index_id,
+                'query': {v['field']: v['value'] for v in query},
+                'kwargs': kwargs,
+            },
         }
         try:
             return self._send_request(payload)

--- a/hyperon_das/das.py
+++ b/hyperon_das/das.py
@@ -418,10 +418,10 @@ class DistributedAtomSpace:
 
     def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
         """
-        Count Atoms or nodes and links in DAS.
+        Count atoms, nodes and links in DAS.
 
-        By default, the precise parameter is set to False returning the total number of atoms, node and link count
-        will be zero. If the precise parameter is True it will return the total of nodes and links and atoms.
+        By default, the precise parameter is set to False returning the total number of atoms, without node and link
+        counts. If the precise parameter is True it will return the total of nodes and links and atoms.
 
         In the case of remote DAS, count the total number of nodes and links stored locally and
         remotely. If there are more than one instance of the same atom (local and remote), it's
@@ -429,8 +429,8 @@ class DistributedAtomSpace:
 
         Args:
             parameters (Optional[Dict[str, Any]]): Dict containing the following keys: 'context' - returning the
-                count of 'local', 'remote' or 'both', 'precise' - boolean sets the count precision as 'precise' if True
-                 or 'fast' if False.
+                count of 'local', 'remote' or 'both', 'precise' - boolean if True provides an accurate but slower count,
+                if False the count will be an estimate, which is faster but less precise.
                 Default value for 'context' is 'both' and for 'precise' is False.
                 Defaults to None.
 

--- a/hyperon_das/das.py
+++ b/hyperon_das/das.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 from hyperon_das_atomdb import AtomDB, AtomDoesNotExist
 from hyperon_das_atomdb.adapters import InMemoryDB, RedisMongoDB
@@ -416,12 +416,12 @@ class DistributedAtomSpace:
         """
         return self.query_engine.get_incoming_links(atom_handle, **kwargs)
 
-    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
         """
         Count Atoms or nodes and links in DAS.
 
-        By default, the precision is fast returning the total number of atoms, if the precision is 'precise'  it will
-        return the total of nodes and links.
+        By default, the precise parameter is set to False returning the total number of atoms, node and link count
+        will be zero. If the precise parameter is True it will return the total of nodes and links and atoms.
 
         In the case of remote DAS, count the total number of nodes and links stored locally and
         remotely. If there are more than one instance of the same atom (local and remote), it's
@@ -429,12 +429,13 @@ class DistributedAtomSpace:
 
         Args:
             parameters (Optional[Dict[str, Any]]): Dict containing the following keys: 'context' - returning the
-                count of 'local', 'remote' or 'both', 'precision' - sets the count precision as 'precise' or 'fast'.
-                Default value for 'context' is 'both' and 'precision' is 'fast'.
+                count of 'local', 'remote' or 'both', 'precise' - boolean sets the count precision as 'precise' if True
+                 or 'fast' if False.
+                Default value for 'context' is 'both' and for 'precise' is False.
                 Defaults to None.
 
         Returns:
-            Tuple[int, int]: (node_count or atom_count, link_count) 'link_count' is zero if the precision is 'fast'
+            Dict[str, int]: Dict containing the keys 'node_count', 'atom_count', 'link_count'.
         """
         return self.query_engine.count_atoms(parameters)
 

--- a/hyperon_das/das.py
+++ b/hyperon_das/das.py
@@ -416,7 +416,7 @@ class DistributedAtomSpace:
         """
         return self.query_engine.get_incoming_links(atom_handle, **kwargs)
 
-    def count_atoms(self) -> Tuple[int, int]:
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
         """
         Count nodes and links in DAS.
 
@@ -424,10 +424,16 @@ class DistributedAtomSpace:
         remotely. If there are more than one instance of the same atom (local and remote), it's
         counted only once.
 
+        Args:
+            parameters (Optional[Dict[str, Any]]): Dict containing the following keys: 'context' - returning the
+                count of 'local', 'remote' or 'both', 'precision' - sets the count precision as 'precise' or 'fast'.
+                Default value for 'context' is 'both' and 'precision' is 'precise'.
+                Defaults to None.
+
         Returns:
             Tuple[int, int]: (node_count, link_count)
         """
-        return self.query_engine.count_atoms()
+        return self.query_engine.count_atoms(parameters)
 
     def query(
         self,

--- a/hyperon_das/das.py
+++ b/hyperon_das/das.py
@@ -418,7 +418,10 @@ class DistributedAtomSpace:
 
     def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
         """
-        Count nodes and links in DAS.
+        Count Atoms or nodes and links in DAS.
+
+        By default, the precision is fast returning the total number of atoms, if the precision is 'precise'  it will
+        return the total of nodes and links.
 
         In the case of remote DAS, count the total number of nodes and links stored locally and
         remotely. If there are more than one instance of the same atom (local and remote), it's
@@ -427,11 +430,11 @@ class DistributedAtomSpace:
         Args:
             parameters (Optional[Dict[str, Any]]): Dict containing the following keys: 'context' - returning the
                 count of 'local', 'remote' or 'both', 'precision' - sets the count precision as 'precise' or 'fast'.
-                Default value for 'context' is 'both' and 'precision' is 'precise'.
+                Default value for 'context' is 'both' and 'precision' is 'fast'.
                 Defaults to None.
 
         Returns:
-            Tuple[int, int]: (node_count, link_count)
+            Tuple[int, int]: (node_count or atom_count, link_count) 'link_count' is zero if the precision is 'fast'
         """
         return self.query_engine.count_atoms(parameters)
 

--- a/hyperon_das/query_engines/local_query_engine.py
+++ b/hyperon_das/query_engines/local_query_engine.py
@@ -293,7 +293,7 @@ class LocalQueryEngine(QueryEngine):
 
     def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
         if parameters and parameters.get('context') == 'remote':
-            return {'atom_count': 0, 'link_count': 0, 'node_count': 0}
+            return {}
         return self.local_backend.count_atoms(parameters)
 
     def commit(self, **kwargs) -> None:

--- a/hyperon_das/query_engines/local_query_engine.py
+++ b/hyperon_das/query_engines/local_query_engine.py
@@ -291,9 +291,9 @@ class LocalQueryEngine(QueryEngine):
             kwargs['cursor'] = cursor
             return CustomQuery(ListIterator(answer), **kwargs)
 
-    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
         if parameters and parameters.get('context') == 'remote':
-            return 0, 0
+            return {'atom_count': 0, 'link_count': 0, 'node_count': 0}
         return self.local_backend.count_atoms(parameters)
 
     def commit(self, **kwargs) -> None:

--- a/hyperon_das/query_engines/local_query_engine.py
+++ b/hyperon_das/query_engines/local_query_engine.py
@@ -291,8 +291,10 @@ class LocalQueryEngine(QueryEngine):
             kwargs['cursor'] = cursor
             return CustomQuery(ListIterator(answer), **kwargs)
 
-    def count_atoms(self) -> Tuple[int, int]:
-        return self.local_backend.count_atoms()
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
+        if parameters and parameters.get('context') == 'remote':
+            return 0, 0
+        return self.local_backend.count_atoms(parameters)
 
     def commit(self, **kwargs) -> None:
         if kwargs.get('buffer'):

--- a/hyperon_das/query_engines/query_engine_protocol.py
+++ b/hyperon_das/query_engines/query_engine_protocol.py
@@ -165,7 +165,7 @@ class QueryEngine(ABC):
         ...
 
     @abstractmethod
-    def count_atoms(self) -> Tuple[int, int]:
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
         """
         Counts the total number of atoms in the database.
 

--- a/hyperon_das/query_engines/query_engine_protocol.py
+++ b/hyperon_das/query_engines/query_engine_protocol.py
@@ -165,18 +165,19 @@ class QueryEngine(ABC):
         ...
 
     @abstractmethod
-    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
         """
         Counts the total number of atoms in the database.
 
         This method aggregates the count of all atoms stored within the database, providing a
-        comprehensive overview of the total number of atoms. It returns a tuple where the first
-        element represents the count of node atoms, and the second element represents the count of
-        link atoms.
+        comprehensive overview of the total number of atoms. It returns a dict where the key 'node_count'  represents
+        the count of node atoms, the key 'link_count' represents the count of link atoms, the key 'atom_count'
+        represents the total of atoms .
 
         Returns:
-            Tuple[int, int]: A tuple containing two integers, where the first integer is the count of
-            node atoms and the second is the count of link atoms.
+            Dict[str, int]: A dict containing str keys and integers, where the key 'node_count' has an integer which is
+            the count of node atoms, the key 'link_count' is the count of link atoms and 'atom_count' is the count of
+            all atoms.
         """
         ...
 

--- a/hyperon_das/query_engines/remote_query_engine.py
+++ b/hyperon_das/query_engines/remote_query_engine.py
@@ -139,9 +139,6 @@ class RemoteQueryEngine(QueryEngine):
         return answer
 
     def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
-
-        print('aaaaa', parameters)
-
         if (context := parameters.get('context') if parameters else None) == 'local':
             return self.local_query_engine.count_atoms(parameters)
         if context == 'remote':
@@ -150,8 +147,6 @@ class RemoteQueryEngine(QueryEngine):
         local_answer = self.local_query_engine.count_atoms(parameters)
         remote_answer = self.remote_das.count_atoms(parameters)
         return tuple([x + y for x, y in zip(local_answer, remote_answer)])
-
-
 
     def commit(self, **kwargs) -> None:
         if self.__mode == 'read-write':

--- a/hyperon_das/query_engines/remote_query_engine.py
+++ b/hyperon_das/query_engines/remote_query_engine.py
@@ -138,10 +138,20 @@ class RemoteQueryEngine(QueryEngine):
             )
         return answer
 
-    def count_atoms(self) -> Tuple[int, int]:
-        local_answer = self.local_query_engine.count_atoms()
-        remote_answer = self.remote_das.count_atoms()
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
+
+        print('aaaaa', parameters)
+
+        if (context := parameters.get('context') if parameters else None) == 'local':
+            return self.local_query_engine.count_atoms(parameters)
+        if context == 'remote':
+            return self.remote_das.count_atoms(parameters)
+
+        local_answer = self.local_query_engine.count_atoms(parameters)
+        remote_answer = self.remote_das.count_atoms(parameters)
         return tuple([x + y for x, y in zip(local_answer, remote_answer)])
+
+
 
     def commit(self, **kwargs) -> None:
         if self.__mode == 'read-write':

--- a/hyperon_das/query_engines/remote_query_engine.py
+++ b/hyperon_das/query_engines/remote_query_engine.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 from hyperon_das_atomdb.exceptions import AtomDoesNotExist, LinkDoesNotExist, NodeDoesNotExist
 
@@ -138,7 +138,7 @@ class RemoteQueryEngine(QueryEngine):
             )
         return answer
 
-    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[int, int]:
+    def count_atoms(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
         if (context := parameters.get('context') if parameters else None) == 'local':
             return self.local_query_engine.count_atoms(parameters)
         if context == 'remote':
@@ -146,8 +146,12 @@ class RemoteQueryEngine(QueryEngine):
 
         local_answer = self.local_query_engine.count_atoms(parameters)
         remote_answer = self.remote_das.count_atoms(parameters)
-        return tuple([x + y for x, y in zip(local_answer, remote_answer)])
+        return {
+            k: (local_answer.get(k, 0) + remote_answer.get(k, 0))
+            for k in ['node_count', 'link_count', 'atom_count']
+        }
 
+    #
     def commit(self, **kwargs) -> None:
         if self.__mode == 'read-write':
             if self.local_query_engine.has_buffer():

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -83,10 +83,10 @@ class TestVultrClientIntegration:
         assert len(links1) == 43
         assert len(links2) == 43
 
+    @pytest.mark.skip('Waiting new version')
     def test_count_atoms(self, server: FunctionsClient):
         ret = server.count_atoms()
-        assert ret[0] == 23
-        assert ret[1] == 60
+        assert ret == {'atom_count': 83, 'node_count': 23, 'link_count': 60}
 
     def test_query(self, server: FunctionsClient):
         server.get_links('Expression', no_iterator=True)

--- a/tests/integration/test_iterators.py
+++ b/tests/integration/test_iterators.py
@@ -510,7 +510,7 @@ class TestCustomQuery:
         das.commit_changes()
         self._asserts(das)
 
-    @pytest.mark.skip("Skipping to new version")
+    @pytest.mark.skip("Waiting fix")
     def test_custom_query_with_remote_das(self):
         das = DistributedAtomSpace(
             query_engine='remote', host=remote_das_host, port=remote_das_port

--- a/tests/integration/test_local_das.py
+++ b/tests/integration/test_local_das.py
@@ -28,7 +28,8 @@ class TestLocalDASRedisMongo:
         load_animals_base(das)
         assert das.count_atoms() == (0, 0)
         das.commit_changes()
-        assert das.count_atoms() == (14, 26)
+        assert das.count_atoms() == (40, 0)
+        assert das.count_atoms({'precision': 'precise'}) == (14, 26)
 
         _db_down()
 
@@ -48,7 +49,7 @@ class TestLocalDASRedisMongo:
         load_animals_base(das)
         assert das.count_atoms() == (0, 0)
         das.commit_changes()
-        assert das.count_atoms() == (14, 26)
+        assert das.count_atoms() == (40, 0)
         assert das.count_atoms({'context': 'remote'}) == (0, 0)
 
         das.add_node({"type": "Concept", "name": "dog"})
@@ -62,7 +63,7 @@ class TestLocalDASRedisMongo:
             }
         )
         das.commit_changes()
-        assert das.count_atoms() == (15, 27)
+        assert das.count_atoms({'precision': 'precise'}) == (15, 27)
 
         das2 = DistributedAtomSpace(
             query_engine='local',
@@ -74,7 +75,7 @@ class TestLocalDASRedisMongo:
             redis_cluster=False,
             redis_ssl=False,
         )
-        assert das2.count_atoms() == (15, 27)
+        assert das2.count_atoms({'precision': 'precise'}) == (15, 27)
 
         _db_down()
 
@@ -104,7 +105,7 @@ class TestLocalDASRedisMongo:
             host=remote_das_host,
             port=remote_das_port,
         )
-        assert das.count_atoms() == (6, 4)
+        assert das.count_atoms({'precision': 'precise'}) == (6, 4)
         _db_down()
 
 
@@ -125,4 +126,4 @@ class TestLocalDASRamOnly:
             host=remote_das_host,
             port=remote_das_port,
         )
-        assert das.count_atoms() == (6, 4)
+        assert das.count_atoms({'precision': 'precise'}) == (6, 4)

--- a/tests/integration/test_local_das.py
+++ b/tests/integration/test_local_das.py
@@ -24,12 +24,16 @@ class TestLocalDASRedisMongo:
             redis_cluster=False,
             redis_ssl=False,
         )
-        assert das.count_atoms() == (0, 0)
+        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
         load_animals_base(das)
-        assert das.count_atoms() == (0, 0)
+        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
         das.commit_changes()
-        assert das.count_atoms() == (40, 0)
-        assert das.count_atoms({'precision': 'precise'}) == (14, 26)
+        assert das.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
+        assert das.count_atoms({'precise': True}) == {
+            'atom_count': 40,
+            'node_count': 14,
+            'link_count': 26,
+        }
 
         _db_down()
 
@@ -45,12 +49,16 @@ class TestLocalDASRedisMongo:
             redis_cluster=False,
             redis_ssl=False,
         )
-        assert das.count_atoms() == (0, 0)
+        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
         load_animals_base(das)
-        assert das.count_atoms() == (0, 0)
+        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
         das.commit_changes()
-        assert das.count_atoms() == (40, 0)
-        assert das.count_atoms({'context': 'remote'}) == (0, 0)
+        assert das.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
+        assert das.count_atoms({'context': 'remote'}) == {
+            'atom_count': 0,
+            'node_count': 0,
+            'link_count': 0,
+        }
 
         das.add_node({"type": "Concept", "name": "dog"})
         das.add_link(
@@ -63,7 +71,11 @@ class TestLocalDASRedisMongo:
             }
         )
         das.commit_changes()
-        assert das.count_atoms({'precision': 'precise'}) == (15, 27)
+        assert das.count_atoms({'precise': True}) == {
+            'atom_count': 42,
+            'node_count': 15,
+            'link_count': 27,
+        }
 
         das2 = DistributedAtomSpace(
             query_engine='local',
@@ -75,7 +87,11 @@ class TestLocalDASRedisMongo:
             redis_cluster=False,
             redis_ssl=False,
         )
-        assert das2.count_atoms({'precision': 'precise'}) == (15, 27)
+        assert das2.count_atoms({'precise': True}) == {
+            'atom_count': 42,
+            'node_count': 15,
+            'link_count': 27,
+        }
 
         _db_down()
 
@@ -91,7 +107,7 @@ class TestLocalDASRedisMongo:
             redis_cluster=False,
             redis_ssl=False,
         )
-        assert das.count_atoms() == (0, 0)
+        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
         das.fetch(
             query={
                 "atom_type": "link",
@@ -105,14 +121,18 @@ class TestLocalDASRedisMongo:
             host=remote_das_host,
             port=remote_das_port,
         )
-        assert das.count_atoms({'precision': 'precise'}) == (6, 4)
+        assert das.count_atoms({'precise': True}) == {
+            'atom_count': 10,
+            'node_count': 6,
+            'link_count': 4,
+        }
         _db_down()
 
 
 class TestLocalDASRamOnly:
     def test_fetch_atoms_local_das_ram_only(self):
         das = DistributedAtomSpace()
-        assert das.count_atoms() == (0, 0)
+        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
         das.fetch(
             query={
                 "atom_type": "link",
@@ -126,4 +146,8 @@ class TestLocalDASRamOnly:
             host=remote_das_host,
             port=remote_das_port,
         )
-        assert das.count_atoms({'precision': 'precise'}) == (6, 4)
+        assert das.count_atoms({'precise': True}) == {
+            'atom_count': 10,
+            'node_count': 6,
+            'link_count': 4,
+        }

--- a/tests/integration/test_local_das.py
+++ b/tests/integration/test_local_das.py
@@ -49,6 +49,7 @@ class TestLocalDASRedisMongo:
         assert das.count_atoms() == (0, 0)
         das.commit_changes()
         assert das.count_atoms() == (14, 26)
+        assert das.count_atoms({'context': 'remote'}) == (0, 0)
 
         das.add_node({"type": "Concept", "name": "dog"})
         das.add_link(

--- a/tests/integration/test_local_das.py
+++ b/tests/integration/test_local_das.py
@@ -24,11 +24,11 @@ class TestLocalDASRedisMongo:
             redis_cluster=False,
             redis_ssl=False,
         )
-        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert das.count_atoms() == {'atom_count': 0}
         load_animals_base(das)
-        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert das.count_atoms() == {'atom_count': 0}
         das.commit_changes()
-        assert das.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
+        assert das.count_atoms() == {'atom_count': 40}
         assert das.count_atoms({'precise': True}) == {
             'atom_count': 40,
             'node_count': 14,
@@ -49,16 +49,12 @@ class TestLocalDASRedisMongo:
             redis_cluster=False,
             redis_ssl=False,
         )
-        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert das.count_atoms() == {'atom_count': 0}
         load_animals_base(das)
-        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert das.count_atoms() == {'atom_count': 0}
         das.commit_changes()
-        assert das.count_atoms() == {'atom_count': 40, 'node_count': 0, 'link_count': 0}
-        assert das.count_atoms({'context': 'remote'}) == {
-            'atom_count': 0,
-            'node_count': 0,
-            'link_count': 0,
-        }
+        assert das.count_atoms() == {'atom_count': 40}
+        assert das.count_atoms({'context': 'remote'}) == {}
 
         das.add_node({"type": "Concept", "name": "dog"})
         das.add_link(
@@ -107,7 +103,7 @@ class TestLocalDASRedisMongo:
             redis_cluster=False,
             redis_ssl=False,
         )
-        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert das.count_atoms() == {'atom_count': 0}
         das.fetch(
             query={
                 "atom_type": "link",
@@ -132,7 +128,7 @@ class TestLocalDASRedisMongo:
 class TestLocalDASRamOnly:
     def test_fetch_atoms_local_das_ram_only(self):
         das = DistributedAtomSpace()
-        assert das.count_atoms() == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
+        assert das.count_atoms() == {'atom_count': 0, 'link_count': 0, 'node_count': 0}
         das.fetch(
             query={
                 "atom_type": "link",

--- a/tests/integration/test_remote_das.py
+++ b/tests/integration/test_remote_das.py
@@ -157,10 +157,9 @@ class TestRemoteDistributedAtomSpace:
 
     def _test_count_atoms(self, remote_das: DistributedAtomSpace):
         response = remote_das.count_atoms()
-        assert response[0] == 23
-        assert response[1] == 60
+        assert response == {'atom_count': 83, 'node_count': 23, 'link_count': 60}
         response_local = remote_das.count_atoms({'context': 'local'})
-        assert response_local == (0, 0)
+        assert response_local == {'atom_count': 0, 'node_count': 0, 'link_count': 0}
 
     def _test_query(self, remote_das: DistributedAtomSpace):
         all_inheritance_mammal = [
@@ -318,7 +317,11 @@ class TestRemoteDistributedAtomSpace:
         assert cursor.get()['handle'] == metta_animal_base_handles.human
 
     def _test_fetch_atoms(self, remote_das):
-        assert remote_das.backend.count_atoms() == (0, 0)
+        assert remote_das.backend.count_atoms() == {
+            'atom_count': 0,
+            'node_count': 0,
+            'link_count': 0,
+        }
         remote_das.fetch(
             query={
                 "atom_type": "link",
@@ -330,12 +333,24 @@ class TestRemoteDistributedAtomSpace:
                 ],
             }
         )
-        assert remote_das.backend.count_atoms() == (6, 4)
+        assert remote_das.backend.count_atoms() == {
+            'atom_count': 10,
+            'node_count': 6,
+            'link_count': 4,
+        }
 
     def _test_fetch_all_data(self, remote_das):
-        assert remote_das.backend.count_atoms() == (0, 0)
+        assert remote_das.backend.count_atoms() == {
+            'atom_count': 0,
+            'node_count': 0,
+            'link_count': 0,
+        }
         remote_das.fetch()
-        assert remote_das.backend.count_atoms() == (23, 60)
+        assert remote_das.backend.count_atoms() == {
+            'atom_count': 83,
+            'node_count': 23,
+            'link_count': 60,
+        }
 
     @pytest.mark.skip(reason="Disabled. See https://github.com/singnet/das-query-engine/issues/256")
     def test_create_context(self, remote_das):

--- a/tests/integration/test_remote_das.py
+++ b/tests/integration/test_remote_das.py
@@ -159,6 +159,8 @@ class TestRemoteDistributedAtomSpace:
         response = remote_das.count_atoms()
         assert response[0] == 23
         assert response[1] == 60
+        response_local = remote_das.count_atoms({'context': 'local'})
+        assert response_local == (0, 0)
 
     def _test_query(self, remote_das: DistributedAtomSpace):
         all_inheritance_mammal = [

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -6,6 +6,8 @@ from hyperon_das_atomdb import WILDCARD, AtomDB
 from hyperon_das import DistributedAtomSpace
 from hyperon_das.das import LocalQueryEngine, RemoteQueryEngine
 
+from unittest.mock import MagicMock, patch
+
 
 def _build_node_handle(node_type: str, node_name: str) -> str:
     return f'<{node_type}: {node_name}>'
@@ -26,7 +28,8 @@ class DistributedAtomSpaceMock(DistributedAtomSpace):
     def __init__(self, query_engine: Optional[str] = 'local', **kwargs) -> None:
         self.backend = DatabaseAnimals()
         if query_engine == 'remote':
-            self.query_engine = RemoteQueryEngine(self.backend, {}, kwargs)
+            with patch('hyperon_das.client.connect_to_server', return_value=(200, 'OK')):
+                self.query_engine = RemoteQueryEngine(self.backend, {}, kwargs)
         else:
             self.query_engine = LocalQueryEngine(self.backend, {}, kwargs)
 
@@ -292,7 +295,7 @@ class DatabaseMock(AtomDB):
         document = self.get_atom_as_dict(node_handle)
         return document["type"]
 
-    def count_atoms(self):
+    def count_atoms(self, parameters: Dict[str, Any] = None):
         return (len(self.all_nodes), len(self.all_links))
 
     def clear_database(self):

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -1,12 +1,11 @@
 import re
 from typing import Any, Dict, List, Optional, Tuple, Union
+from unittest.mock import patch
 
 from hyperon_das_atomdb import WILDCARD, AtomDB
 
 from hyperon_das import DistributedAtomSpace
 from hyperon_das.das import LocalQueryEngine, RemoteQueryEngine
-
-from unittest.mock import MagicMock, patch
 
 
 def _build_node_handle(node_type: str, node_name: str) -> str:

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -294,8 +294,13 @@ class DatabaseMock(AtomDB):
         document = self.get_atom_as_dict(node_handle)
         return document["type"]
 
-    def count_atoms(self, parameters: Dict[str, Any] = None):
-        return (len(self.all_nodes), len(self.all_links))
+    def count_atoms(self, parameters: Dict[str, Any] = None) -> Dict[str, int]:
+        return {
+            'link_count': len(self.all_links),
+            'node_count': len(self.all_nodes),
+            'atom_count': len(self.all_links) + len(self.all_nodes),
+        }
+        # return (len(self.all_nodes), len(self.all_links))
 
     def clear_database(self):
         pass

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -314,6 +314,24 @@ class TestFunctionsClient:
 
         assert result == expected_response
 
+    def test_count_atoms_success_parameters(self, mock_request, client):
+        values = {'parameters': {'context': 'local'}}
+        expected_request_data = {"action": "count_atoms", "input": values}
+        expected_response = (14, 26)
+
+        mock_request.return_value.status_code = 200
+        mock_request.return_value.content = serialize(expected_response)
+        result = client.count_atoms(values['parameters'])
+
+        mock_request.assert_called_once_with(
+            method='POST',
+            url='http://0.0.0.0:1000/function/query-engine',
+            data=serialize(expected_request_data),
+            headers={'Content-Type': 'application/octet-stream'},
+        )
+
+        assert result == expected_response
+
     def test_get_atoms_by_field(self, mock_request, client):
         query = [{'field': 'name', 'value': 'test'}]
         expected_request_data = {

--- a/tests/unit/test_das.py
+++ b/tests/unit/test_das.py
@@ -107,3 +107,41 @@ class TestDistributedAtomSpace:
         das = DistributedAtomSpaceMock()
         atom_starting_with = das.get_node_by_name_starting_with('Concept', 'mon')
         assert atom_starting_with
+
+    def test_count_atoms(self):
+        das = DistributedAtomSpaceMock()
+        atom_count = das.count_atoms()
+        assert atom_count == (14, 26)
+
+    def test_count_atoms_local(self):
+        das = DistributedAtomSpaceMock()
+        atom_count = das.count_atoms({'context': 'local'})
+        assert atom_count == (14, 26)
+
+    def test_count_atoms_local_remote(self):
+        das = DistributedAtomSpaceMock()
+        atom_count = das.count_atoms({'context': 'remote'})
+        assert atom_count == (0, 0)
+
+    def test_count_atoms_local_both(self):
+        das = DistributedAtomSpaceMock()
+        atom_count = das.count_atoms({'context': 'both'})
+        assert atom_count == (14, 26)
+
+    def test_count_atoms_remote(self):
+        das = DistributedAtomSpaceMock('remote', host='localhost', port=123)
+        with mock.patch(
+            'hyperon_das.client.FunctionsClient.count_atoms',
+            return_value=(10, 0),
+        ):
+            atom_count = das.count_atoms({'context': 'remote'})
+        assert atom_count == (10, 0)
+
+    def test_count_atoms_both(self):
+        das = DistributedAtomSpaceMock('remote', host='localhost', port=123)
+        with mock.patch(
+            'hyperon_das.client.FunctionsClient.count_atoms',
+            return_value=(10, 0),
+        ):
+            atom_count = das.count_atoms({'context': 'both'})
+        assert atom_count == (24, 26)

--- a/tests/unit/test_das.py
+++ b/tests/unit/test_das.py
@@ -111,22 +111,23 @@ class TestDistributedAtomSpace:
     def test_count_atoms(self):
         das = DistributedAtomSpaceMock()
         atom_count = das.count_atoms()
-        assert atom_count == (14, 26)
+        assert atom_count == {'link_count': 26, 'node_count': 14, 'atom_count': 40}
 
     def test_count_atoms_local(self):
         das = DistributedAtomSpaceMock()
         atom_count = das.count_atoms({'context': 'local'})
-        assert atom_count == (14, 26)
+        assert atom_count == {'link_count': 26, 'node_count': 14, 'atom_count': 40}
 
     def test_count_atoms_local_remote(self):
         das = DistributedAtomSpaceMock()
         atom_count = das.count_atoms({'context': 'remote'})
-        assert atom_count == (0, 0)
+        assert atom_count == {'link_count': 0, 'node_count': 0, 'atom_count': 0}
 
     def test_count_atoms_local_both(self):
         das = DistributedAtomSpaceMock()
         atom_count = das.count_atoms({'context': 'both'})
-        assert atom_count == (14, 26)
+        assert atom_count == {'link_count': 26, 'node_count': 14, 'atom_count': 40}
+        # assert atom_count == (14, 26)
 
     def test_count_atoms_remote(self):
         das = DistributedAtomSpaceMock('remote', host='localhost', port=123)
@@ -141,7 +142,8 @@ class TestDistributedAtomSpace:
         das = DistributedAtomSpaceMock('remote', host='localhost', port=123)
         with mock.patch(
             'hyperon_das.client.FunctionsClient.count_atoms',
-            return_value=(10, 0),
+            return_value={'link_count': 0, 'node_count': 10, 'atom_count': 0},
         ):
             atom_count = das.count_atoms({'context': 'both'})
-        assert atom_count == (24, 26)
+        # assert atom_count == (24, 26)
+        assert atom_count == {'link_count': 26, 'node_count': 24, 'atom_count': 40}

--- a/tests/unit/test_das.py
+++ b/tests/unit/test_das.py
@@ -121,7 +121,7 @@ class TestDistributedAtomSpace:
     def test_count_atoms_local_remote(self):
         das = DistributedAtomSpaceMock()
         atom_count = das.count_atoms({'context': 'remote'})
-        assert atom_count == {'link_count': 0, 'node_count': 0, 'atom_count': 0}
+        assert atom_count == {}
 
     def test_count_atoms_local_both(self):
         das = DistributedAtomSpaceMock()


### PR DESCRIPTION
Added count remote/local/both and precision, API changes:
- count_atoms(self) -> count_atoms(self, parameters: Optional[Dict[str, Any]] = None)