### PR TITLE
[singnet/das#62] raising an exception when python version is lower than the required

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ A data manipulation API for Distributed Atomspace (DAS). It allows queries with 
 
 ## Installation
 
-> Before you start, make sure you have [Python](https://www.python.org/) >= 3.10 and [Pip]
-> (https://pypi.org/project/pip/) installed on your system.
+> Before you start, make sure you have [Python](https://www.python.org/) >= 3.10 and [Pip](https://pypi.org/project/pip/) installed on your system.
 
 You can install and run this project using different methods. Choose the one that suits your needs.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A data manipulation API for Distributed Atomspace (DAS). It allows queries with 
 
 ## Installation
 
-> Before you start, make sure you have [Python](https://www.python.org/) >= 3.8.5 and [Pip](https://pypi.org/project/pip/) installed on your system.
+> Before you start, make sure you have [Python](https://www.python.org/) >= 3.10 and [Pip]
+> (https://pypi.org/project/pip/) installed on your system.
 
 You can install and run this project using different methods. Choose the one that suits your needs.
 

--- a/hyperon_das/__init__.py
+++ b/hyperon_das/__init__.py
@@ -1,3 +1,9 @@
+import sys
+
+if sys.version_info < (3, 10):
+    print('hyperon_das requires Python 3.10 or higher')
+    sys.exit(1)
+
 from hyperon_das.das import DistributedAtomSpace
 
 __all__ = ['DistributedAtomSpace']

--- a/hyperon_das/__init__.py
+++ b/hyperon_das/__init__.py
@@ -1,8 +1,7 @@
 import sys
 
 if sys.version_info < (3, 10):
-    print('hyperon_das requires Python 3.10 or higher')
-    sys.exit(1)
+    raise RuntimeError('hyperon_das requires Python 3.10 or higher')
 
 from hyperon_das.das import DistributedAtomSpace
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 "Releases" = "https://github.com/singnet/das-query-engine/releases"
 
 [tool.poetry.dependencies]
-python = "^3.8.5"
+python = "^3.10"
 hyperon-das-atomdb = "0.7.0"
 requests = "^2.31.0"
 grpcio = "^1.62.2"


### PR DESCRIPTION
Solves https://github.com/singnet/das/issues/62

If python version is lower than 3.10, when trying to import `hyperon_das`, an exception will be raised, like this:
```python
>>> import hyperon_das
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/hyperon_das/__init__.py", line 4, in <module>
    raise RuntimeError('hyperon_das requires Python 3.10 or higher')
RuntimeError: hyperon_das requires Python 3.10 or higher
```

