### PR TITLE
[#305] Integration of AttentionBroker server to allow enabling of Cache Controller

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,1 @@
-
+[#305] Integration of AttentionBroker server to allow enabling of Cache Controller

--- a/hyperon_das/cache/attention_broker_gateway.py
+++ b/hyperon_das/cache/attention_broker_gateway.py
@@ -1,3 +1,4 @@
+from time import sleep
 from typing import Any, Dict, Optional, Set
 
 import grpc
@@ -51,6 +52,7 @@ class AttentionBrokerGateway:
             f'Requesting AttentionBroker at {self.server_url} to correlate {len(handle_set)} atoms'
         )
         message = grpc_types.HandleList(handle_list=handle_set)
+        sleep(0.05)
         with grpc.insecure_channel(self.server_url) as channel:
             stub = AttentionBrokerStub(channel)
             response = stub.correlate(message)

--- a/hyperon_das/das.py
+++ b/hyperon_das/das.py
@@ -944,7 +944,7 @@ class DistributedAtomSpace:
         name: str,
         queries: Optional[List[Query]] = [],
     ) -> Context:
-        if self.system_parameters.get('running_on_server'):
+        if self.query_engine_type == 'local':
             return self._create_context(name, queries)
         else:
             return self.query_engine.create_context(name, queries)

--- a/tests/performance/test_mongo_redis_performance.py
+++ b/tests/performance/test_mongo_redis_performance.py
@@ -289,9 +289,11 @@ class TestPerformance:
             links_letter = self.generate_links_letter(node_list)
             self.link_letter_count = len(links_letter)
             words_times_letter = (self.word_range[1] - self.word_range[0]) * (
-                    self.letter_range[1] - self.letter_range[0]
+                self.letter_range[1] - self.letter_range[0]
             )
-            self.add_links(das, links_letter, node_list, 'Similarity', strength_divisor=words_times_letter)
+            self.add_links(
+                das, links_letter, node_list, 'Similarity', strength_divisor=words_times_letter
+            )
             count_atoms_links_nodes: dict[str, int] = self.count_atoms(das, {'precise': True})
             self.count_atoms(das)
             TestPerformance.is_database_loaded = True

--- a/tests/unit/test_das.py
+++ b/tests/unit/test_das.py
@@ -90,8 +90,8 @@ class TestDistributedAtomSpace:
 
     def test_create_context(self):
         das = DistributedAtomSpace()
-        with pytest.raises(NotImplementedError):
-            das.create_context("blah", {})
+        context = das.create_context("blah", {})
+        assert context.name == "blah"
 
     def test_get_atoms_by_field(self):
         das = DistributedAtomSpaceMock()


### PR DESCRIPTION
Related to https://github.com/singnet/das/issues/43

Now it's possible to enable the Cache Controller (using a SystemParameter in DAS' constructor) but the default is still to let it disabled.