### PR TITLE
[#307] Change get_atom() to check if atom is present in the cache before forwarding the query to remote DAS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,3 @@
 [#305] Integration of AttentionBroker server to allow enabling of Cache Controller
 [#308] Change get_node() and get_link() to reuse get_atom()
+[#307] Change get_atom() to check is atom is present in the cache before forwarding the query to remote DAS

--- a/hyperon_das/cache/cache_controller.py
+++ b/hyperon_das/cache/cache_controller.py
@@ -83,4 +83,4 @@ class CacheController:
         Returns:
             Optional[Dict[str, Any]]: Atom document or None if the atom is not in local cache
         """
-        return atom_table.get(handle, None)
+        return self.atom_table.get(handle, None)

--- a/hyperon_das/cache/cache_controller.py
+++ b/hyperon_das/cache/cache_controller.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from hyperon_das.cache.attention_broker_gateway import AttentionBrokerGateway
 from hyperon_das.context import Context
@@ -13,12 +13,12 @@ class CacheController:
     engines use it to check for query answers if they are available locally before forwarding
     these queries to a remote DAS.
     """
-    def __init__(self, system_parameters):
+    def __init__(self, system_parameters: Dict[str, Any]):
         """
         System parameters are allowed to change dinamically after the CacheController
         object is created. So the behavior of the CacheController regarding each parameter
         may change accordingly. That's why individual system parameters are not stored individually
-        as object fields. The whole passed SystemParameters object is stored instead and 
+        as object fields. The whole passed system parameter's dict object is stored instead and 
         checked everytime CacheController behavior is supposed to be controlled by some 
         parameter. For example, the method enabled() will always check for the proper parameter
         in order to answer if CacheController is enabled or disabled.
@@ -30,6 +30,7 @@ class CacheController:
             }
         """
         self.system_parameters = system_parameters
+        self.atom_table = {}
         if self.enabled():
             self.attention_broker = AttentionBrokerGateway(system_parameters)
 
@@ -74,3 +75,12 @@ class CacheController:
             return
         for query_answer in context.query_answers:
             self.regard_query_answer(query_answer)
+
+    def get_atom(self, handle: str) -> Optional[Dict[str, Any]]:
+        """
+        Returns the corresponding atom if it's present in the local cache or None otherwise.
+
+        Returns:
+            Optional[Dict[str, Any]]: Atom document or None if the atom is not in local cache
+        """
+        return atom_table.get(handle, None)

--- a/hyperon_das/cache/cache_controller.py
+++ b/hyperon_das/cache/cache_controller.py
@@ -13,18 +13,19 @@ class CacheController:
     engines use it to check for query answers if they are available locally before forwarding
     these queries to a remote DAS.
     """
+
     def __init__(self, system_parameters: Dict[str, Any]):
         """
         System parameters are allowed to change dinamically after the CacheController
         object is created. So the behavior of the CacheController regarding each parameter
         may change accordingly. That's why individual system parameters are not stored individually
-        as object fields. The whole passed system parameter's dict object is stored instead and 
-        checked everytime CacheController behavior is supposed to be controlled by some 
+        as object fields. The whole passed system parameter's dict object is stored instead and
+        checked everytime CacheController behavior is supposed to be controlled by some
         parameter. For example, the method enabled() will always check for the proper parameter
         in order to answer if CacheController is enabled or disabled.
 
         Args:
-            system_parameters (Dict[str, Any], optional): Relevant parameters and their defaults: 
+            system_parameters (Dict[str, Any], optional): Relevant parameters and their defaults:
             {
                 'cache_enabled': False
             }

--- a/hyperon_das/cache/cache_controller.py
+++ b/hyperon_das/cache/cache_controller.py
@@ -6,15 +6,48 @@ from hyperon_das.utils import QueryAnswer
 
 
 class CacheController:
+    """
+    CacheController is the class used by query engines to interface with the caching sub-system.
+
+    Local query engines feed the cache sub-system as queries are processed while remote query
+    engines use it to check for query answers if they are available locally before forwarding
+    these queries to a remote DAS.
+    """
     def __init__(self, system_parameters):
+        """
+        System parameters are allowed to change dinamically after the CacheController
+        object is created. So the behavior of the CacheController regarding each parameter
+        may change accordingly. That's why individual system parameters are not stored individually
+        as object fields. The whole passed SystemParameters object is stored instead and 
+        checked everytime CacheController behavior is supposed to be controlled by some 
+        parameter. For example, the method enabled() will always check for the proper parameter
+        in order to answer if CacheController is enabled or disabled.
+
+        Args:
+            system_parameters (Dict[str, Any], optional): Relevant parameters and their defaults: 
+            {
+                'cache_enabled': False
+            }
+        """
         self.system_parameters = system_parameters
         if self.enabled():
             self.attention_broker = AttentionBrokerGateway(system_parameters)
 
     def enabled(self):
+        """
+        Returns True iff the cache sub-system is enabled (as defined by a system parameter).
+        """
         return self.system_parameters.get("cache_enabled")
 
     def regard_query_answer(self, query_answer: List[QueryAnswer]):
+        """
+        Feed this CacheController with the answers of a query made by an user. These answers are
+        used to feed the cache itself and to allow the AttentionBroker to update its Hebbian
+        Links properly.
+
+        Args:
+            query_answer (List[QueryANswer]): List of QueryAnswer objects.
+        """
         if not self.enabled():
             return
         joint_count = {}
@@ -28,6 +61,15 @@ class CacheController:
         self.attention_broker.stimulate(joint_count)
 
     def add_context(self, context: Context):
+        """
+        Creates a new context to attach importance of atoms.
+
+        Args:
+            context (Context): new COntext object to be added.
+
+        Contexts are used by the AttentionBroker in order to keep different importance values for
+        atoms in different contexts.
+        """
         if not self.enabled():
             return
         for query_answer in context.query_answers:

--- a/hyperon_das/das.py
+++ b/hyperon_das/das.py
@@ -114,7 +114,9 @@ class DistributedAtomSpace:
 
     def _start_query_engine(self, engine_type, das_type, **kwargs):
         self._das_type = das_type
-        self.query_engine = engine_type(self.backend, self.cache_controller, self.system_parameters, kwargs)
+        self.query_engine = engine_type(
+            self.backend, self.cache_controller, self.system_parameters, kwargs
+        )
         logger().info(f"Started {das_type} DAS")
 
     def _create_context(

--- a/hyperon_das/das.py
+++ b/hyperon_das/das.py
@@ -114,7 +114,7 @@ class DistributedAtomSpace:
 
     def _start_query_engine(self, engine_type, das_type, **kwargs):
         self._das_type = das_type
-        self.query_engine = engine_type(self.backend, self.system_parameters, kwargs)
+        self.query_engine = engine_type(self.backend, self.cache_controller, self.system_parameters, kwargs)
         logger().info(f"Started {das_type} DAS")
 
     def _create_context(

--- a/hyperon_das/das.py
+++ b/hyperon_das/das.py
@@ -73,8 +73,8 @@ class DistributedAtomSpace:
         self.query_engine_type = kwargs.get('query_engine', 'local')
         self._set_default_system_parameters()
         self._set_backend(**kwargs)
-        self._set_query_engine(**kwargs)
         self.cache_controller = CacheController(self.system_parameters)
+        self._set_query_engine(**kwargs)
 
     def _set_default_system_parameters(self) -> None:
         # Internals

--- a/hyperon_das/query_engines/local_query_engine.py
+++ b/hyperon_das/query_engines/local_query_engine.py
@@ -5,6 +5,7 @@ from hyperon_das_atomdb import WILDCARD, AtomDB
 from hyperon_das_atomdb.adapters import InMemoryDB
 from hyperon_das_atomdb.exceptions import AtomDoesNotExist
 
+from hyperon_das.cache.cache_controller import CacheController
 from hyperon_das.cache.iterators import (
     AndEvaluator,
     CustomQuery,
@@ -15,7 +16,6 @@ from hyperon_das.cache.iterators import (
     QueryAnswerIterator,
 )
 from hyperon_das.client import FunctionsClient
-from hyperon_das.cache.cache_controller import CacheController
 from hyperon_das.context import Context
 from hyperon_das.exceptions import UnexpectedQueryFormat
 from hyperon_das.logger import logger
@@ -26,11 +26,11 @@ from hyperon_das.utils import Assignment, QueryAnswer, das_error
 
 class LocalQueryEngine(QueryEngine):
     def __init__(
-        self, 
-        backend, 
-        cache_controller: CacheController, 
-        system_parameters: Dict[str, Any], 
-        kwargs: Optional[dict] = {}
+        self,
+        backend,
+        cache_controller: CacheController,
+        system_parameters: Dict[str, Any],
+        kwargs: Optional[dict] = {},
     ) -> None:
         self.system_parameters = system_parameters
         self.local_backend = backend

--- a/hyperon_das/query_engines/local_query_engine.py
+++ b/hyperon_das/query_engines/local_query_engine.py
@@ -15,6 +15,7 @@ from hyperon_das.cache.iterators import (
     QueryAnswerIterator,
 )
 from hyperon_das.client import FunctionsClient
+from hyperon_das.cache.cache_controller import CacheController
 from hyperon_das.context import Context
 from hyperon_das.exceptions import UnexpectedQueryFormat
 from hyperon_das.logger import logger
@@ -25,10 +26,15 @@ from hyperon_das.utils import Assignment, QueryAnswer, das_error
 
 class LocalQueryEngine(QueryEngine):
     def __init__(
-        self, backend, system_parameters: Dict[str, Any], kwargs: Optional[dict] = {}
+        self, 
+        backend, 
+        cache_controller: CacheController, 
+        system_parameters: Dict[str, Any], 
+        kwargs: Optional[dict] = {}
     ) -> None:
         self.system_parameters = system_parameters
         self.local_backend = backend
+        self.cache_controller = cache_controller
 
     def _recursive_query(
         self,

--- a/hyperon_das/query_engines/remote_query_engine.py
+++ b/hyperon_das/query_engines/remote_query_engine.py
@@ -27,7 +27,7 @@ class RemoteQueryEngine(QueryEngine):
         kwargs: Optional[dict] = {}
     ):
         self.system_parameters = system_parameters
-        self.local_query_engine = LocalQueryEngine(backend, kwargs)
+        self.local_query_engine = LocalQueryEngine(backend, cache_controller, kwargs)
         self.cache_controller = cache_controller
         self.__mode = kwargs.get('mode', 'read-only')
         self.host = kwargs.get('host')

--- a/hyperon_das/query_engines/remote_query_engine.py
+++ b/hyperon_das/query_engines/remote_query_engine.py
@@ -41,13 +41,15 @@ class RemoteQueryEngine(QueryEngine):
         return self.__mode
 
     def get_atom(self, handle: str, **kwargs) -> Dict[str, Any]:
-        try:
-            atom = self.local_query_engine.get_atom(handle, **kwargs)
-        except AtomDoesNotExist:
+        atom = self.cache_controller.get_atom(handle)
+        if atom is None:
             try:
-                atom = self.remote_das.get_atom(handle, **kwargs)
-            except AtomDoesNotExist as exception:
-                das_error(exception)
+                atom = self.local_query_engine.get_atom(handle, **kwargs)
+            except AtomDoesNotExist:
+                try:
+                    atom = self.remote_das.get_atom(handle, **kwargs)
+                except AtomDoesNotExist as exception:
+                    das_error(exception)
         return atom
 
     def get_links(

--- a/hyperon_das/query_engines/remote_query_engine.py
+++ b/hyperon_das/query_engines/remote_query_engine.py
@@ -8,6 +8,7 @@ from hyperon_das.cache.iterators import (
     RemoteGetLinks,
     RemoteIncomingLinks,
 )
+from hyperon_das.cache.cache_controller import CacheController
 from hyperon_das.client import FunctionsClient
 from hyperon_das.context import Context
 from hyperon_das.exceptions import InvalidDASParameters, QueryParametersException
@@ -18,9 +19,16 @@ from hyperon_das.utils import QueryAnswer, das_error
 
 
 class RemoteQueryEngine(QueryEngine):
-    def __init__(self, backend, system_parameters: Dict[str, Any], kwargs: Optional[dict] = {}):
+    def __init__(
+        self, 
+        backend, 
+        cache_controller: CacheController, 
+        system_parameters: Dict[str, Any], 
+        kwargs: Optional[dict] = {}
+    ):
         self.system_parameters = system_parameters
         self.local_query_engine = LocalQueryEngine(backend, kwargs)
+        self.cache_controller = cache_controller
         self.__mode = kwargs.get('mode', 'read-only')
         self.host = kwargs.get('host')
         self.port = kwargs.get('port')

--- a/hyperon_das/query_engines/remote_query_engine.py
+++ b/hyperon_das/query_engines/remote_query_engine.py
@@ -2,13 +2,13 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 
 from hyperon_das_atomdb.exceptions import AtomDoesNotExist
 
+from hyperon_das.cache.cache_controller import CacheController
 from hyperon_das.cache.iterators import (
     CustomQuery,
     ListIterator,
     RemoteGetLinks,
     RemoteIncomingLinks,
 )
-from hyperon_das.cache.cache_controller import CacheController
 from hyperon_das.client import FunctionsClient
 from hyperon_das.context import Context
 from hyperon_das.exceptions import InvalidDASParameters, QueryParametersException
@@ -20,11 +20,11 @@ from hyperon_das.utils import QueryAnswer, das_error
 
 class RemoteQueryEngine(QueryEngine):
     def __init__(
-        self, 
-        backend, 
-        cache_controller: CacheController, 
-        system_parameters: Dict[str, Any], 
-        kwargs: Optional[dict] = {}
+        self,
+        backend,
+        cache_controller: CacheController,
+        system_parameters: Dict[str, Any],
+        kwargs: Optional[dict] = {},
     ):
         self.system_parameters = system_parameters
         self.local_query_engine = LocalQueryEngine(backend, cache_controller, kwargs)

--- a/tests/integration/test_remote_das.py
+++ b/tests/integration/test_remote_das.py
@@ -48,9 +48,7 @@ class TestRemoteDistributedAtomSpace:
 
     def test_cache_controller(self, remote_das: DistributedAtomSpace):
         remote_das.cache_controller.atom_table["h1"] = {"handle": "h1"}
-        query_engine = RemoteQueryEngine(None, cache_controller, {}, {"host": "blah", "port": "blah"})
-        atom = query_engine.get_atom("h1")
-        assert atom["handle"] == "h1"
+        assert remote_das.backend.get_atom("h1")["handle"] == "h1"
 
     def _test_get_atom(self, remote_das: DistributedAtomSpace):
         result = remote_das.get_atom(handle=metta_animal_base_handles.human)

--- a/tests/integration/test_remote_das.py
+++ b/tests/integration/test_remote_das.py
@@ -46,6 +46,12 @@ class TestRemoteDistributedAtomSpace:
             == f'http://{remote_das_host}:{remote_das_port}/function/query-engine'
         )
 
+    def test_cache_controller(self, remote_das: DistributedAtomSpace):
+        remote_das.cache_controller.atom_table["h1"] = {"handle": "h1"}
+        query_engine = RemoteQueryEngine(None, cache_controller, {}, {"host": "blah", "port": "blah"})
+        atom = query_engine.get_atom("h1")
+        assert atom["handle"] == "h1"
+
     def _test_get_atom(self, remote_das: DistributedAtomSpace):
         result = remote_das.get_atom(handle=metta_animal_base_handles.human)
         assert result['handle'] == metta_animal_base_handles.human

--- a/tests/integration/test_remote_das.py
+++ b/tests/integration/test_remote_das.py
@@ -48,7 +48,8 @@ class TestRemoteDistributedAtomSpace:
 
     def test_cache_controller(self, remote_das: DistributedAtomSpace):
         remote_das.cache_controller.atom_table["h1"] = {"handle": "h1"}
-        assert remote_das.backend.get_atom("h1")["handle"] == "h1"
+        print(remote_das.cache_controller.atom_table["h1"])
+        assert remote_das.query_engine.get_atom("h1")["handle"] == "h1"
 
     def _test_get_atom(self, remote_das: DistributedAtomSpace):
         result = remote_das.get_atom(handle=metta_animal_base_handles.human)

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -27,12 +27,12 @@ def _build_link_handle(link_type: str, target_handles: List[str]) -> str:
 class DistributedAtomSpaceMock(DistributedAtomSpace):
     def __init__(self, query_engine: Optional[str] = 'local', **kwargs) -> None:
         self.backend = DatabaseAnimals()
-        self.cache_controller = CacheController()
+        self.cache_controller = CacheController({})
         if query_engine == 'remote':
             with patch('hyperon_das.client.connect_to_server', return_value=(200, 'OK')):
-                self.query_engine = RemoteQueryEngine(self.backend, {}, kwargs)
+                self.query_engine = RemoteQueryEngine(self.backend, self.cache_controller, {}, kwargs)
         else:
-            self.query_engine = LocalQueryEngine(self.backend, {}, kwargs)
+            self.query_engine = LocalQueryEngine(self.backend, self.cache_controller, {}, kwargs)
 
 
 class DatabaseMock(AtomDB):

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from hyperon_das_atomdb import WILDCARD, AtomDB
 
 from hyperon_das import DistributedAtomSpace
+from hyperon_das.cache.cache_controller import CacheController
 from hyperon_das.das import LocalQueryEngine, RemoteQueryEngine
 
 
@@ -26,6 +27,7 @@ def _build_link_handle(link_type: str, target_handles: List[str]) -> str:
 class DistributedAtomSpaceMock(DistributedAtomSpace):
     def __init__(self, query_engine: Optional[str] = 'local', **kwargs) -> None:
         self.backend = DatabaseAnimals()
+        self.cache_controller = CacheController()
         if query_engine == 'remote':
             with patch('hyperon_das.client.connect_to_server', return_value=(200, 'OK')):
                 self.query_engine = RemoteQueryEngine(self.backend, {}, kwargs)

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -30,7 +30,9 @@ class DistributedAtomSpaceMock(DistributedAtomSpace):
         self.cache_controller = CacheController({})
         if query_engine == 'remote':
             with patch('hyperon_das.client.connect_to_server', return_value=(200, 'OK')):
-                self.query_engine = RemoteQueryEngine(self.backend, self.cache_controller, {}, kwargs)
+                self.query_engine = RemoteQueryEngine(
+                    self.backend, self.cache_controller, {}, kwargs
+                )
         else:
             self.query_engine = LocalQueryEngine(self.backend, self.cache_controller, {}, kwargs)
 

--- a/tests/unit/test_cache_controller.py
+++ b/tests/unit/test_cache_controller.py
@@ -43,6 +43,10 @@ class TestCacheController:
         controller = CacheController({'cache_enabled': False})
         assert not controller.enabled()
 
+    def test_get_atom(self):
+        controller = CacheController({})
+        controller.get_atom('blah') == None
+
     def test_add_context(self):
         controller = self._build_controller()
         context = Context(

--- a/tests/unit/test_cache_controller.py
+++ b/tests/unit/test_cache_controller.py
@@ -45,7 +45,7 @@ class TestCacheController:
 
     def test_get_atom(self):
         controller = CacheController({})
-        controller.get_atom('blah') == None
+        assert controller.get_atom('blah') is None
 
     def test_add_context(self):
         controller = self._build_controller()


### PR DESCRIPTION
After this PR, RemoteQueryEngine checks the cache for the presence searched atoms in get_atom() before forwarding the request to remote DAS but the code to actually feed the cache is still missing.

Resolves #307 