### PR TITLE
[das-atom-db/#188] WIP - Implementation of get_atom() using the cache

### DIFF
--- a/hyperon_das/cache/cache_controller.py
+++ b/hyperon_das/cache/cache_controller.py
@@ -66,11 +66,12 @@ class CacheController:
         """
         Creates a new context to attach importance of atoms.
 
+        Contexts are used by the AttentionBroker in order to keep different importance values for
+        atoms in different contexts.
+
         Args:
             context (Context): new COntext object to be added.
 
-        Contexts are used by the AttentionBroker in order to keep different importance values for
-        atoms in different contexts.
         """
         if not self.enabled():
             return
@@ -85,3 +86,15 @@ class CacheController:
             Optional[Dict[str, Any]]: Atom document or None if the atom is not in local cache
         """
         return self.atom_table.get(handle, None)
+
+    def get_atoms(self, handles: List[str]) -> List[Dict[str, Any]]:
+        """
+        Return a list of atoms given their handles.
+
+        Args:
+            handles (List[str]): List of handles.
+
+        Returns:
+            List[Dict[str, Any]]
+        """
+        raise NotImplementedError()

--- a/hyperon_das/das.py
+++ b/hyperon_das/das.py
@@ -153,7 +153,7 @@ class DistributedAtomSpace:
         }
 
     @staticmethod
-    def get_node_handle(node_type: str, node_name: str) -> str:
+    def compute_node_handle(node_type: str, node_name: str) -> str:
         """
         Computes the handle of a node, given its type and name.
 
@@ -172,14 +172,14 @@ class DistributedAtomSpace:
 
         Examples:
             >>> das = DistributedAtomSpace()
-            >>> result = das.get_node_handle(node_type='Concept', node_name='human')
+            >>> result = das.compute_node_handle(node_type='Concept', node_name='human')
             >>> print(result)
             "af12f10f9ae2002a1607ba0b47ba8407"
         """
         return AtomDB.node_handle(node_type, node_name)
 
     @staticmethod
-    def get_link_handle(link_type: str, link_targets: List[str]) -> str:
+    def compute_link_handle(link_type: str, link_targets: List[str]) -> str:
         """
         Computes the handle of a link, given its type and targets' handles.
 
@@ -198,26 +198,28 @@ class DistributedAtomSpace:
 
         Examples:
             >>> das = DistributedAtomSpace()
-            >>> human_handle = das.get_node_handle(node_type='Concept', node_name='human')
-            >>> monkey_handle = das.get_node_handle(node_type='Concept', node_name='monkey')
-            >>> result = das.get_link_handle(link_type='Similarity', targets=[human_handle, monkey_handle])
+            >>> human_handle = das.compute_node_handle(node_type='Concept', node_name='human')
+            >>> monkey_handle = das.compute_node_handle(node_type='Concept', node_name='monkey')
+            >>> result = das.compute_link_handle(link_type='Similarity', targets=[human_handle, monkey_handle])
             >>> print(result)
             "bad7472f41a0e7d601ca294eb4607c3a"
 
         """
         return AtomDB.link_handle(link_type, link_targets)
 
-    def get_atom(self, handle: str, **kwargs) -> Dict[str, Any]:
+    def get_atom(self, handle: str) -> Dict[str, Any]:
         """
-        Retrieve an atom given its handle, handles for atoms can be created by using the function 'get_node_handle'.
-        A handle is MD5 hash of a node in the graph.
+        Retrieve an atom given its handle.
 
+        A handle is a MD5 hash of a node in the graph. It cam be computed using `compute_node_handle()' or `compute_link_handle()`.
 
         Args:
             handle (str): Atom's handle.
 
         Keyword Args:
-            no_target_format (bool, optional): Set this parameter to True to get MongoDB's default output. Defaults to False.
+            no_target_format (bool, optional): If True, a list of target handles is returned in
+                link's `targets` field. If False, a list with actual target documents is returned
+                instead. Defaults to False.
             targets_document (bool, optional): Set this parameter to True to return a tuple containing the document as first element
                 and the targets as second element. Defaults to False.
 
@@ -229,7 +231,7 @@ class DistributedAtomSpace:
 
         Examples:
             >>> das = DistributedAtomSpace()
-            >>> human_handle = das.get_node_handle(node_type='Concept', node_name='human')
+            >>> human_handle = das.compute_node_handle(node_type='Concept', node_name='human')
             >>> result = das.get_atom(human_handle)
             >>> print(result)
             {
@@ -239,7 +241,49 @@ class DistributedAtomSpace:
                 'named_type': 'Concept'
             }
         """
-        return self.query_engine.get_atom(handle, **kwargs)
+        return self.query_engine.get_atom(handle, no_target_format=True)
+
+    def get_atoms(self, handles: List[str]) -> List[Dict[str, Any]]:
+        """
+        Retrieve atoms given a list of handles.
+
+        A handle is a MD5 hash of a node in the graph. It cam be computed using
+        `compute_node_handle()' or `compute_link_handle()`.
+
+        It is preferable to call get atoms() passing a list of handles rather than
+        repeatedly calling get_atom() for each handle because get_atoms() makes at
+        most one remote request, if necessary.
+
+        Args:
+            handles (List[str]): List with Atom's handles.
+
+        Returns:
+            Dict: A list of Python dicts with all atom data.
+
+        Raises:
+            AtomDoesNotExist: If some of the atoms doesn't exist.
+
+        Examples:
+            >>> das = DistributedAtomSpace()
+            >>> human_handle = das.compute_node_handle(node_type='Concept', node_name='human')
+            >>> animal_handle = das.compute_node_handle(node_type='Concept', node_name='monkey')
+            >>> result = das.get_atoms([human_handle, animal_handle])
+            >>> print(result[0])
+            >>> print(result[1])
+            {
+                'handle': 'af12f10f9ae2002a1607ba0b47ba8407',
+                'composite_type_hash': 'd99a604c79ce3c2e76a2f43488d5d4c3',
+                'name': 'human',
+                'named_type': 'Concept'
+            }
+            {
+                'handle': '1cdffc6b0b89ff41d68bec237481d1e1'
+                'composite_type_hash': 'd99a604c79ce3c2e76a2f43488d5d4c3',
+                'name': 'monkey',
+                'named_type': 'Concept'
+            }
+        """
+        return self.query_engine.get_atoms(handles, no_target_format=True)
 
     def get_node(self, node_type: str, node_name: str) -> Dict[str, Any]:
         """
@@ -275,7 +319,7 @@ class DistributedAtomSpace:
     def get_link(self, link_type: str, link_targets: List[str]) -> Dict[str, Any]:
         """
         Retrieve a link given its type and list of targets.
-        Targets are hashes of the nodes these hashes or handles can be created using the function 'get_node_handle'.
+        Targets are hashes of the nodes these hashes or handles can be created using the function 'compute_node_handle'.
 
         Args:
             link_type (str): Link type
@@ -289,8 +333,8 @@ class DistributedAtomSpace:
 
         Examples:
             >>> das = DistributedAtomSpace()
-            >>> human_handle = das.get_node_handle('Concept', 'human')
-            >>> monkey_handle = das.get_node_handle('Concept', 'monkey')
+            >>> human_handle = das.compute_node_handle('Concept', 'human')
+            >>> monkey_handle = das.compute_node_handle('Concept', 'monkey')
             >>> result = das.get_link(
                     link_type='Similarity',
                     link_targets=[human_handle, monkey_handle],
@@ -391,7 +435,7 @@ class DistributedAtomSpace:
             3. Retrieve all the links of a given type whose targets match a given list of
                handles
 
-                >>> snake = das.get_node_handle('Concept', 'snake')
+                >>> snake = das.compute_node_handle('Concept', 'snake')
                 >>> links = das.get_links(link_type='Similarity', link_targets=[snake, '*'])
                 >>> for link in links:
                 >>>     print(link['type'], link['targets'])
@@ -422,7 +466,7 @@ class DistributedAtomSpace:
 
         Examples:
             >>> das = DistributedAtomSpace()
-            >>> rhino = das.get_node_handle('Concept', 'rhino')
+            >>> rhino = das.compute_node_handle('Concept', 'rhino')
             >>> links = das.get_incoming_links(rhino)
             >>> for link in links:
             >>>     print(link['type'], link['targets'])

--- a/hyperon_das/query_engines/local_query_engine.py
+++ b/hyperon_das/query_engines/local_query_engine.py
@@ -202,11 +202,14 @@ class LocalQueryEngine(QueryEngine):
             return bool(atoms)
         return False
 
-    def get_atom(self, handle: str, **kwargs) -> Union[Dict[str, Any], None]:
+    def get_atom(self, handle: str, **kwargs) -> Dict[str, Any]:
         try:
             return self.local_backend.get_atom(handle, **kwargs)
         except AtomDoesNotExist as exception:
             das_error(exception)
+
+    def get_atoms(self, handles: str, **kwargs) -> List[Dict[str, Any]]:
+        return [self.local_backend.get_atom(handle, **kwargs) for handle in handles]
 
     def get_links(
         self,

--- a/hyperon_das/query_engines/query_engine_protocol.py
+++ b/hyperon_das/query_engines/query_engine_protocol.py
@@ -10,18 +10,36 @@ from hyperon_das.utils import QueryAnswer
 
 class QueryEngine(ABC):
     @abstractmethod
-    def get_atom(self, handle: str) -> Union[Dict[str, Any], None]:
+    def get_atom(self, handle: str) -> Dict[str, Any]:
         """
         Retrieves an atom from the database using its unique handle.
 
         This method searches the database for an atom with the specified handle. If found, it returns
-        the atom's data as a dictionary. If no atom with the given handle exists, it returns None.
+        the atom's data as a dictionary. If no atom with the given handle exists, an exception is thrown.
 
         Args:
             handle (str): The unique handle of the atom to retrieve.
 
         Returns:
-            Union[Dict[str, Any], None]: A dictionary containing the atom's data if found, otherwise None.
+            Dict[str, Any]: A dictionary containing the atom's data.
+        """
+        ...
+
+    @abstractmethod
+    def get_atoms(self, handles: List[str]) -> List[Dict[str, Any]]:
+        """
+        Retrieves atoms from the database using their unique handles.
+
+        This method searches the database for atoms with the specified handles and return them in a list
+        or throw an exception if any of them doesn't exist.
+
+        Remote query engines do a single request to remote DAS in order to get all the requested atoms.
+
+        Args:
+            handles (List[str]): Unique handle of the atoms to retrieve.
+
+        Returns:
+            List[Dict[str, Any]]: List with requested atoms.
         """
         ...
 

--- a/hyperon_das/query_engines/remote_query_engine.py
+++ b/hyperon_das/query_engines/remote_query_engine.py
@@ -53,6 +53,9 @@ class RemoteQueryEngine(QueryEngine):
                     das_error(exception)
         return atom
 
+    def get_atoms(self, handles: List[str]) -> List[Dict[str, Any]]:
+        return self.cache_controller.get_atoms(handles)
+
     def get_links(
         self,
         link_type: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-hyperon-das-atomdb = "0.8.0"
+hyperon-das-atomdb = "0.8.1"
 requests = "^2.31.0"
 grpcio = "^1.62.2"
 google = "^3.0.0"

--- a/tests/integration/test_iterators.py
+++ b/tests/integration/test_iterators.py
@@ -267,7 +267,9 @@ class TestTraverseLinks:
 
     def _check_asserts(self, das: DistributedAtomSpace, iterator: QueryAnswerIterator):
         current_value = iterator.get()
-        assert current_value == das.query_engine.get_atom(iterator.get()['handle'], targets_document=True)
+        assert current_value == das.query_engine.get_atom(
+            iterator.get()['handle'], targets_document=True
+        )
         assert isinstance(current_value, dict)
         assert iterator.is_empty() is False
         link_handles = sorted([item['handle'] for item in iterator])

--- a/tests/integration/test_iterators.py
+++ b/tests/integration/test_iterators.py
@@ -267,7 +267,7 @@ class TestTraverseLinks:
 
     def _check_asserts(self, das: DistributedAtomSpace, iterator: QueryAnswerIterator):
         current_value = iterator.get()
-        assert current_value == das.get_atom(iterator.get()['handle'], targets_document=True)
+        assert current_value == das.query_engine.get_atom(iterator.get()['handle'], targets_document=True)
         assert isinstance(current_value, dict)
         assert iterator.is_empty() is False
         link_handles = sorted([item['handle'] for item in iterator])

--- a/tests/integration/test_metta_api.py
+++ b/tests/integration/test_metta_api.py
@@ -107,13 +107,13 @@ class TestMettaAPI:
             assert len(answer) == 2
             for qa in answer:
                 handle = qa.assignment.mapping["$v2"]
-                assert handle == das.get_node_handle(
+                assert handle == das.compute_node_handle(
                     "Symbol", "2"
-                ) or handle == das.get_link_handle(
+                ) or handle == das.compute_link_handle(
                     "Expression",
                     [
-                        das.get_node_handle("Symbol", "Test"),
-                        das.get_node_handle("Symbol", "2"),
+                        das.compute_node_handle("Symbol", "Test"),
+                        das.compute_node_handle("Symbol", "2"),
                     ],
                 )
                 atom = das.get_atom(handle)
@@ -149,16 +149,16 @@ class TestMettaAPI:
             assert len(answer) == 2
             for qa in answer:
                 handle = qa.assignment.mapping["$v"]
-                if handle == das.get_node_handle("Symbol", "Test"):
+                if handle == das.compute_node_handle("Symbol", "Test"):
                     symbol = das.get_atom(handle)
                     assert symbol["type"] == "Symbol"
                     assert symbol["name"] == "Test"
                     handle = answer[0].assignment.mapping["$x"]
-                    assert handle == das.get_link_handle(
+                    assert handle == das.compute_link_handle(
                         "Expression",
                         [
-                            das.get_node_handle("Symbol", "Test"),
-                            das.get_node_handle("Symbol", "2"),
+                            das.compute_node_handle("Symbol", "Test"),
+                            das.compute_node_handle("Symbol", "2"),
                         ],
                     )
                     symbol = das.get_atom(handle)
@@ -169,16 +169,16 @@ class TestMettaAPI:
                     symbol2 = das.get_atom(symbol["targets"][1])
                     assert symbol2["type"] == "Symbol"
                     assert symbol2["name"] == "2"
-                elif handle == das.get_node_handle("Symbol", "Best"):
+                elif handle == das.compute_node_handle("Symbol", "Best"):
                     symbol = das.get_atom(handle)
                     assert symbol["type"] == "Symbol"
                     assert symbol["name"] == "Best"
                     handle = answer[1].assignment.mapping["$x"]
-                    assert handle == das.get_link_handle(
+                    assert handle == das.compute_link_handle(
                         "Expression",
                         [
-                            das.get_node_handle("Symbol", "Test"),
-                            das.get_node_handle("Symbol", "2"),
+                            das.compute_node_handle("Symbol", "Test"),
+                            das.compute_node_handle("Symbol", "2"),
                         ],
                     )
                     symbol = das.get_atom(handle)

--- a/tests/unit/test_das.py
+++ b/tests/unit/test_das.py
@@ -69,7 +69,7 @@ class TestDistributedAtomSpace:
     def test_get_traversal_cursor(self):
         das = DistributedAtomSpace()
         das.add_node({'type': 'Concept', 'name': 'human'})
-        human = das.get_node_handle('Concept', 'human')
+        human = das.compute_node_handle('Concept', 'human')
 
         cursor = das.get_traversal_cursor(human)
 
@@ -79,6 +79,55 @@ class TestDistributedAtomSpace:
             das.get_traversal_cursor(handle='snet')
 
         assert exc.value.message == 'Cannot start Traversal. Atom does not exist'
+
+    def test_get_atom(self):
+        das = DistributedAtomSpace()
+        das.add_link(
+            {
+                'type': 'expression',
+                'targets': [
+                    {'type': 'symbol', 'name': 'a'},
+                    {
+                        'type': 'expression',
+                        'targets': [
+                            {'type': 'symbol', 'name': 'b'},
+                            {'type': 'symbol', 'name': 'c'},
+                        ],
+                    },
+                ],
+            }
+        )
+
+        handle = {}
+        for n in ['a', 'b', 'c']:
+            handle[n] = das.compute_node_handle('symbol', n)
+
+        handle['internal_link'] = das.compute_link_handle('expression', [handle['b'], handle['c']])
+        handle['external_link'] = das.compute_link_handle(
+            'expression', [handle['a'], handle['internal_link']]
+        )
+
+        for n in ['a', 'b', 'c']:
+            document = das.get_atom(handle[n])
+            assert document['type'] == 'symbol'
+            assert document['name'] == n
+            assert document['handle'] == handle[n]
+
+        document = das.get_atom(handle['internal_link'])
+        assert document['type'] == 'expression'
+        assert document['handle'] == handle['internal_link']
+        assert document['targets'] == [handle['b'], handle['c']]
+
+        document = das.get_atom(handle['external_link'])
+        assert document['type'] == 'expression'
+        assert document['handle'] == handle['external_link']
+        assert document['targets'] == [handle['a'], handle['internal_link']]
+
+        assert das.get_atoms([handle['a'], handle['external_link'], handle['c']]) == [
+            das.get_atom(handle['a']),
+            das.get_atom(handle['external_link']),
+            das.get_atom(handle['c']),
+        ]
 
     def test_about(self):
         das = DistributedAtomSpace()


### PR DESCRIPTION
WIP of https://github.com/singnet/das-atom-db/issues/188

In this PR we basically change DAS.get_atom() to return a document (Dict[str, Any]) with the atom. If it's a link, targets handles are returned in `targets` and no option for recursive substitution of such targets by actual documents is available.

Another change is in the query engines to make them aware of the cache. Remote query engines now checks in a cache for an atom when get_atom() is called. In the case of cache hit, no remote request is made. But the cache itself is not being populated yet so, in proactive, for now, all get_atom() calls will still make a remote call.