### PR TITLE
[das-atom-db/#199] [HOTFIX] Deep copy atoms in LazyQueryEvaluator 

### DIFF
--- a/hyperon_das/cache/iterators.py
+++ b/hyperon_das/cache/iterators.py
@@ -1,3 +1,5 @@
+import copy
+
 from abc import ABC, abstractmethod
 from collections import deque
 from itertools import product
@@ -100,8 +102,9 @@ class LazyQueryEvaluator(ProductIterator):
             if atom.get("targets", None) is not None:
                 atom = self._replace_target_handles(atom)
             targets.append(atom)
-        link["targets"] = targets
-        return link
+        answer = copy.deepcopy(link)
+        answer["targets"] = targets
+        return answer
 
     def __next__(self):
         if self.buffered_answer:

--- a/hyperon_das/cache/iterators.py
+++ b/hyperon_das/cache/iterators.py
@@ -1,5 +1,4 @@
 import copy
-
 from abc import ABC, abstractmethod
 from collections import deque
 from itertools import product


### PR DESCRIPTION
Related to: https://github.com/singnet/das-atom-db/issues/199

Together with  https://github.com/singnet/das-atom-db/pull/200 , this PR moves the deep copy being made in ram_only.get_atom() to inside LazyQueryEvaluator. This is not a proper solution because LazyQueryEvaluator is being called not only with ram_only but also with redis_mongo. But, on the other hand, LazyQueryEvaluator is one of the many classes being refactored in the context of https://github.com/singnet/das/issues/73 so this issue will be revisited with more context information very soon. For now we'll pay the price of degrading performance with this deep copy since it's required in order to make proper implementation of DAS.get_atom() as implemented in https://github.com/singnet/das-query-engine/pull/322 and https://github.com/singnet/das-atom-db/pull/196

