### PR TITLE
[#338] Change get_links() API to use link filters instead of optional parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,1 @@
-
+[#338] Change get_links() API to use link filters instead of optional parameters

--- a/hyperon_das/cache/iterators.py
+++ b/hyperon_das/cache/iterators.py
@@ -308,42 +308,6 @@ class RemoteIncomingLinks(BaseLinksIterator):
             return self.backend.get_incoming_links(self.atom_handle, **kwargs)
 
 
-class LocalGetLinks(BaseLinksIterator):
-    def __init__(self, source: ListIterator, **kwargs) -> None:
-        self.link_type = kwargs.get('link_type')
-        self.target_types = kwargs.get('target_types')
-        self.link_targets = kwargs.get('link_targets')
-        self.toplevel_only = kwargs.get('toplevel_only')
-        super().__init__(source, **kwargs)
-
-    def get_next_value(self) -> Any:
-        if not self.is_empty() and self.backend:
-            value = next(self.iterator)
-            self.current_value = self.backend._to_link_dict_list([value])[0]
-        return self.current_value
-
-    def get_current_value(self) -> Any:
-        if self.backend:
-            try:
-                value = self.source.get()
-                return self.backend._to_link_dict_list([value])[0]
-            except StopIteration:
-                return None
-
-    def get_fetch_data_kwargs(self) -> Dict[str, Any]:
-        return {
-            'cursor': self.cursor,
-            'chunk_size': self.chunk_size,
-            'toplevel_only': self.toplevel_only,
-        }
-
-    def get_fetch_data(self, **kwargs) -> tuple:
-        if self.backend:
-            return self.backend._get_related_links(
-                self.link_type, self.target_types, self.link_targets, **kwargs
-            )
-
-
 class CustomQuery(BaseLinksIterator):
     def __init__(self, source: ListIterator, **kwargs) -> None:
         self.index_id = kwargs.pop('index_id', None)

--- a/hyperon_das/cache/iterators.py
+++ b/hyperon_das/cache/iterators.py
@@ -7,9 +7,9 @@ from typing import Any, Dict, Iterator, List
 
 from hyperon_das_atomdb import WILDCARD
 
+import hyperon_das.link_filters as link_filters
 from hyperon_das.query_engines.query_engine_protocol import QueryEngine
 from hyperon_das.utils import Assignment, QueryAnswer
-import hyperon_das.link_filters as link_filters
 
 
 class QueryAnswerIterator(ABC):
@@ -126,7 +126,8 @@ class LazyQueryEvaluator(ProductIterator):
                 else:
                     target_handle.append(target["handle"])
             das_query_answer = self.query_engine.get_links(
-                link_filters.Targets(target_handle, self.link_type))
+                link_filters.Targets(target_handle, self.link_type)
+            )
             lazy_query_answer = []
             for answer in das_query_answer:
                 assignment = None

--- a/hyperon_das/link_filters.py
+++ b/hyperon_das/link_filters.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+from hyperon_das_atomdb import WILDCARD
+
+class LinkFilterType(int, Enum):
+    NAMED_TYPE = auto()
+    FLAT_TYPE_TEMPLATE = auto()
+    TARGETS = auto()
+
+@dataclass
+class LinkFilter:
+    filter_type: LinkFilterType
+    toplevel_only: bool
+    link_type: str = None
+    target_types: list[str] = None
+    targets: list[str] = None
+
+@dataclass
+class NamedType(LinkFilter):
+    """
+    All links of a given type. Optionally, only toplevel links are selected.
+    """
+    def __init__(self, link_type: str, toplevel_only: bool = False):
+        filter_type = LinkFilterType.NAMED_TYPE
+        self.link_type = link_type
+        self.toplevel_only = toplevel_only
+
+@dataclass
+class FlatTypeTemplate(LinkFilter):
+    """
+    All links of a given type whose targets are of given types. Any number of wildcards '*' can
+    be used as link or target types.
+    """
+    def __init__(
+        self, 
+        target_types: list[str], 
+        link_type: str = WILDCARD, 
+        toplevel_only: bool = False):
+
+        filter_type = LinkFilterType.FLAT_TYPE_TEMPLATE
+        self.link_type = link_type
+        self.target_types = target_types
+        self.toplevel_only = toplevel_only
+
+@dataclass
+class Targets(LinkFilter):
+    """
+    All links of a given type whose targets match a given list of handles. Any number of
+    wildcards '*' can be used as link type or target handle.
+    """
+    def __init__(self, targets: list[str], link_type: str = WILDCARD, toplevel_only: bool = False):
+        filter_type = LinkFilterType.TARGETS
+        self.link_type = link_type
+        self.targets = targets
+        self.toplevel_only = toplevel_only

--- a/hyperon_das/link_filters.py
+++ b/hyperon_das/link_filters.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
 from enum import Enum, auto
+
 from hyperon_das_atomdb import WILDCARD
+
 
 class LinkFilterType(int, Enum):
     NAMED_TYPE = auto()
     FLAT_TYPE_TEMPLATE = auto()
     TARGETS = auto()
+
 
 @dataclass
 class LinkFilter:
@@ -15,15 +18,18 @@ class LinkFilter:
     target_types: list[str] = None
     targets: list[str] = None
 
+
 @dataclass
 class NamedType(LinkFilter):
     """
     All links of a given type. Optionally, only toplevel links are selected.
     """
+
     def __init__(self, link_type: str, toplevel_only: bool = False):
-        filter_type = LinkFilterType.NAMED_TYPE
+        self.filter_type = LinkFilterType.NAMED_TYPE
         self.link_type = link_type
         self.toplevel_only = toplevel_only
+
 
 @dataclass
 class FlatTypeTemplate(LinkFilter):
@@ -31,16 +37,16 @@ class FlatTypeTemplate(LinkFilter):
     All links of a given type whose targets are of given types. Any number of wildcards '*' can
     be used as link or target types.
     """
-    def __init__(
-        self, 
-        target_types: list[str], 
-        link_type: str = WILDCARD, 
-        toplevel_only: bool = False):
 
-        filter_type = LinkFilterType.FLAT_TYPE_TEMPLATE
+    def __init__(
+        self, target_types: list[str], link_type: str = WILDCARD, toplevel_only: bool = False
+    ):
+
+        self.filter_type = LinkFilterType.FLAT_TYPE_TEMPLATE
         self.link_type = link_type
         self.target_types = target_types
         self.toplevel_only = toplevel_only
+
 
 @dataclass
 class Targets(LinkFilter):
@@ -48,8 +54,9 @@ class Targets(LinkFilter):
     All links of a given type whose targets match a given list of handles. Any number of
     wildcards '*' can be used as link type or target handle.
     """
+
     def __init__(self, targets: list[str], link_type: str = WILDCARD, toplevel_only: bool = False):
-        filter_type = LinkFilterType.TARGETS
+        self.filter_type = LinkFilterType.TARGETS
         self.link_type = link_type
         self.targets = targets
         self.toplevel_only = toplevel_only

--- a/hyperon_das/query_engines/local_query_engine.py
+++ b/hyperon_das/query_engines/local_query_engine.py
@@ -20,7 +20,6 @@ from hyperon_das.cache.iterators import (
     CustomQuery,
     LazyQueryEvaluator,
     ListIterator,
-    LocalGetLinks,
     LocalIncomingLinks,
     QueryAnswerIterator,
 )
@@ -215,10 +214,10 @@ class LocalQueryEngine(QueryEngine):
 
     def get_link_handles(self, link_filter: LinkFilter) -> List[str]:
         _, answer = self._get_related_links(
-            link_type = link_filter.link_type,
-            target_types = link_filter.target_types,
-            link_targets = link_filter.targets,
-            toplevel_only = link_filter.toplevel_only
+            link_type=link_filter.link_type,
+            target_types=link_filter.target_types,
+            link_targets=link_filter.targets,
+            toplevel_only=link_filter.toplevel_only,
         )
         return answer
 

--- a/hyperon_das/query_engines/query_engine_protocol.py
+++ b/hyperon_das/query_engines/query_engine_protocol.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterator, List, Optional, Union
 
-from hyperon_das_atomdb.database import IncomingLinksT
+from hyperon_das_atomdb.database import IncomingLinksT, LinkT
 
 from hyperon_das.context import Context
+from hyperon_das.link_filters import LinkFilter
 from hyperon_das.type_alias import Query
 from hyperon_das.utils import QueryAnswer
 
@@ -44,32 +45,28 @@ class QueryEngine(ABC):
         ...
 
     @abstractmethod
-    def get_links(
-        self,
-        link_type: str,
-        target_types: list[str] | None = None,
-        link_targets: list[str] | None = None,
-        **kwargs,
-    ) -> Union[Iterator, List[str], List[Dict], tuple[int, List[Dict]]]:  # TODO: simplify
+    def get_links(link_filter: LinkFilter) -> List[LinkT]:
         """
-        Retrieves links of a specified type, optionally filtered by target types or specific targets.
-
-        This method can be used to fetch links that match a given link type. Additionally, it allows
-        for filtering based on the types of the targets (target_types) or the specific targets
-        themselves (link_targets). If both target_types and link_targets are provided, the method
-        filters using both criteria.
+        Retrieves all links that match the passed filtering criteria.
 
         Args:
-            link_type (str): The type of links to retrieve. This parameter is mandatory.
-            target_types (List[str], optional): A list of target types to filter the links by. If
-                provided, only links that have targets of these types will be returned. Defaults to None.
-            link_targets (List[str], optional): A list of specific targets to filter the links by. If
-                provided, only links that have these specific targets will be returned. Defaults to None.
+            link_filter (LinkFilter): Filtering criteria to be used to select links
 
         Returns:
-            Union[List[str], List[Dict]]: A list of links that match the criteria. The list contains
-            either strings (handles of the links) or dictionaries (the link objects themselves),
-            depending on the implementation details of the subclass.
+            List[LinkT]: A list of link documents
+        """
+        ...
+
+    @abstractmethod
+    def get_link_handles(link_filter: LinkFilter) -> List[LinkT]:
+        """
+        Retrieve the handle of all links that match the passed filtering criteria.
+
+        Args:
+            link_filter (LinkFilter): Filtering criteria to be used to select links
+
+        Returns:
+            List[str]: A list of link handles
         """
         ...
 

--- a/hyperon_das/query_engines/remote_query_engine.py
+++ b/hyperon_das/query_engines/remote_query_engine.py
@@ -1,15 +1,11 @@
 from enum import Enum
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional
 
 from hyperon_das_atomdb.database import IncomingLinksT, LinkT
 from hyperon_das_atomdb.exceptions import AtomDoesNotExist
 
 from hyperon_das.cache.cache_controller import CacheController
-from hyperon_das.cache.iterators import (
-    CustomQuery,
-    ListIterator,
-    RemoteIncomingLinks,
-)
+from hyperon_das.cache.iterators import CustomQuery, ListIterator, RemoteIncomingLinks
 from hyperon_das.client import FunctionsClient
 from hyperon_das.context import Context
 from hyperon_das.exceptions import InvalidDASParameters, QueryParametersException
@@ -71,17 +67,18 @@ class RemoteQueryEngine(QueryEngine):
         kwargs['cursor'] = 0
         kwargs['toplevel_only'] = link_filter.toplevel_only
         remote_links = self.remote_das.get_links(
-            link_type = link_filter.link_type,
-            target_types = link_filter.target_types,
-            link_targets = link_filter.targets,
-            **kwargs)
+            link_type=link_filter.link_type,
+            target_types=link_filter.target_types,
+            link_targets=link_filter.targets,
+            **kwargs,
+        )
         if isinstance(remote_links, tuple):
             cursor, remote_links = remote_links
         links.extend(remote_links)
         return links
 
     def get_link_handles(self, link_filter: LinkFilter) -> List[str]:
-        #TODO Implement get_link_handles() in faas client
+        # TODO Implement get_link_handles() in faas client
         return [link['handle'] for link in self.get_links(link_filter)]
 
     def get_incoming_links(

--- a/tests/integration/test_iterators.py
+++ b/tests/integration/test_iterators.py
@@ -6,7 +6,6 @@ from hyperon_das import DistributedAtomSpace
 from hyperon_das.cache import QueryAnswerIterator
 from hyperon_das.cache.iterators import (
     CustomQuery,
-    LocalGetLinks,
     LocalIncomingLinks,
     RemoteIncomingLinks,
     TraverseNeighborsIterator,

--- a/tests/integration/test_iterators.py
+++ b/tests/integration/test_iterators.py
@@ -8,7 +8,6 @@ from hyperon_das.cache.iterators import (
     CustomQuery,
     LocalGetLinks,
     LocalIncomingLinks,
-    RemoteGetLinks,
     RemoteIncomingLinks,
     TraverseNeighborsIterator,
 )
@@ -133,108 +132,6 @@ class TestIncomingLinks:
         cursor, iterator = das.get_incoming_links(human_handle)
         assert cursor == 0
         assert isinstance(iterator, (LocalIncomingLinks, RemoteIncomingLinks))
-        self._check_asserts(das, iterator)
-
-
-class TestGetLinks:
-    @pytest.fixture(scope="session")
-    def _cleanup(self, request):
-        return cleanup(request)
-
-    def _expression_links(self) -> list:
-        return sorted(
-            [
-                metta_animal_base_handles.similarity_human_monkey,
-                metta_animal_base_handles.similarity_human_chimp,
-                metta_animal_base_handles.similarity_chimp_monkey,
-                metta_animal_base_handles.similarity_snake_earthworm,
-                metta_animal_base_handles.similarity_rhino_triceratops,
-                metta_animal_base_handles.similarity_snake_vine,
-                metta_animal_base_handles.similarity_human_ent,
-                metta_animal_base_handles.inheritance_human_mammal,
-                metta_animal_base_handles.inheritance_monkey_mammal,
-                metta_animal_base_handles.inheritance_chimp_mammal,
-                metta_animal_base_handles.inheritance_mammal_animal,
-                metta_animal_base_handles.inheritance_reptile_animal,
-                metta_animal_base_handles.inheritance_snake_reptile,
-                metta_animal_base_handles.inheritance_dinosaur_reptile,
-                metta_animal_base_handles.inheritance_triceratops_dinosaur,
-                metta_animal_base_handles.inheritance_earthworm_animal,
-                metta_animal_base_handles.inheritance_rhino_mammal,
-                metta_animal_base_handles.inheritance_vine_plant,
-                metta_animal_base_handles.inheritance_ent_plant,
-                metta_animal_base_handles.similarity_monkey_human,
-                metta_animal_base_handles.similarity_chimp_human,
-                metta_animal_base_handles.similarity_monkey_chimp,
-                metta_animal_base_handles.similarity_earthworm_snake,
-                metta_animal_base_handles.similarity_triceratops_rhino,
-                metta_animal_base_handles.similarity_vine_snake,
-                metta_animal_base_handles.similarity_ent_human,
-                metta_animal_base_handles.human_typedef,
-                metta_animal_base_handles.monkey_typedef,
-                metta_animal_base_handles.chimp_typedef,
-                metta_animal_base_handles.snake_typedef,
-                metta_animal_base_handles.earthworm_typedef,
-                metta_animal_base_handles.rhino_typedef,
-                metta_animal_base_handles.triceratops_typedef,
-                metta_animal_base_handles.vine_typedef,
-                metta_animal_base_handles.ent_typedef,
-                metta_animal_base_handles.mammal_typedef,
-                metta_animal_base_handles.animal_typedef,
-                metta_animal_base_handles.reptile_typedef,
-                metta_animal_base_handles.dinosaur_typedef,
-                metta_animal_base_handles.plant_typedef,
-                metta_animal_base_handles.similarity_typedef,
-                metta_animal_base_handles.inheritance_typedef,
-                metta_animal_base_handles.concept_typedef,
-            ]
-        )
-
-    def _check_asserts(
-        self, das: DistributedAtomSpace, iterator: Union[LocalGetLinks, RemoteGetLinks]
-    ):
-        current_value = iterator.get()
-        assert current_value['handle'] == das.get_atom(iterator.get()['handle'])['handle']
-        assert isinstance(current_value, dict)
-        assert iterator.is_empty() is False
-        link_handles = sorted([item['handle'] for item in iterator])
-        assert len(link_handles) == 43
-        assert link_handles == self._expression_links()
-        assert iterator.is_empty() is True
-        with pytest.raises(StopIteration):
-            iterator.get()
-        with pytest.raises(StopIteration):
-            next(iterator)
-
-    def test_get_links_with_das_ram_only(self):
-        das = DistributedAtomSpace()
-        load_metta_animals_base(das)
-        iterator = das.get_links('Expression', no_iterator=False)
-        self._check_asserts(das, iterator)
-
-    def test_get_links_with_das_redis_mongo(self, _cleanup):
-        _db_up()
-        das = DistributedAtomSpace(
-            query_engine='local',
-            atomdb='redis_mongo',
-            mongo_port=mongo_port,
-            mongo_username='dbadmin',
-            mongo_password='dassecret',
-            redis_port=redis_port,
-            redis_cluster=False,
-            redis_ssl=False,
-        )
-        load_metta_animals_base(das)
-        das.commit_changes()
-        iterator = das.get_links('Expression', no_iterator=False, cursor=0)
-        self._check_asserts(das, iterator)
-        _db_down()
-
-    def test_get_links_with_remote_das(self, _cleanup):
-        das = DistributedAtomSpace(
-            query_engine='remote', host=remote_das_host, port=remote_das_port
-        )
-        iterator = das.get_links('Expression')
         self._check_asserts(das, iterator)
 
 

--- a/tests/integration/test_remote_das.py
+++ b/tests/integration/test_remote_das.py
@@ -3,9 +3,9 @@ from unittest import mock
 import pytest
 from hyperon_das_atomdb import AtomDoesNotExist
 
+import hyperon_das.link_filters as link_filters
 from hyperon_das import DistributedAtomSpace
 from hyperon_das.exceptions import GetTraversalCursorException
-import hyperon_das.link_filters as link_filters
 from hyperon_das.traverse_engines import TraverseEngine
 
 from .helpers import metta_animal_base_handles
@@ -94,9 +94,9 @@ class TestRemoteDistributedAtomSpace:
         assert len(inheritance_links) == 13
         assert sorted(inheritance_links) == sorted(all_inheritance)
 
-        links = remote_das.get_links(link_filters.FlatTypeTemplate(
-            ['Symbol', 'Symbol', 'Symbol'],
-            'Expression'))
+        links = remote_das.get_links(
+            link_filters.FlatTypeTemplate(['Symbol', 'Symbol', 'Symbol'], 'Expression')
+        )
         inheritance_links = []
         for link in links:
             if metta_animal_base_handles.Inheritance in link['targets']:
@@ -104,13 +104,16 @@ class TestRemoteDistributedAtomSpace:
         assert len(inheritance_links) == 13
         assert sorted(inheritance_links) == sorted(all_inheritance)
 
-        link = remote_das.get_links(link_filters.Targets(
-            [
-                metta_animal_base_handles.Inheritance,
-                metta_animal_base_handles.earthworm,
-                metta_animal_base_handles.animal,
-            ],
-            'Expression'))
+        link = remote_das.get_links(
+            link_filters.Targets(
+                [
+                    metta_animal_base_handles.Inheritance,
+                    metta_animal_base_handles.earthworm,
+                    metta_animal_base_handles.animal,
+                ],
+                'Expression',
+            )
+        )
         assert link[0]['handle'] == metta_animal_base_handles.inheritance_earthworm_animal
 
     def test_get_incoming_links(self, remote_das: DistributedAtomSpace):

--- a/tests/integration/test_remote_das.py
+++ b/tests/integration/test_remote_das.py
@@ -5,6 +5,7 @@ from hyperon_das_atomdb import AtomDoesNotExist
 
 from hyperon_das import DistributedAtomSpace
 from hyperon_das.exceptions import GetTraversalCursorException
+import hyperon_das.link_filters as link_filters
 from hyperon_das.traverse_engines import TraverseEngine
 
 from .helpers import metta_animal_base_handles
@@ -85,7 +86,7 @@ class TestRemoteDistributedAtomSpace:
             metta_animal_base_handles.inheritance_typedef,
         ]
 
-        links = remote_das.get_links(link_type='Expression')
+        links = remote_das.get_links(link_filters.NamedType('Expression'))
         inheritance_links = []
         for link in links:
             if metta_animal_base_handles.Inheritance in link['targets']:
@@ -93,9 +94,9 @@ class TestRemoteDistributedAtomSpace:
         assert len(inheritance_links) == 13
         assert sorted(inheritance_links) == sorted(all_inheritance)
 
-        links = remote_das.get_links(
-            link_type='Expression', target_types=['Symbol', 'Symbol', 'Symbol']
-        )
+        links = remote_das.get_links(link_filters.FlatTypeTemplate(
+            ['Symbol', 'Symbol', 'Symbol'],
+            'Expression'))
         inheritance_links = []
         for link in links:
             if metta_animal_base_handles.Inheritance in link['targets']:
@@ -103,15 +104,14 @@ class TestRemoteDistributedAtomSpace:
         assert len(inheritance_links) == 13
         assert sorted(inheritance_links) == sorted(all_inheritance)
 
-        link = remote_das.get_links(
-            link_type='Expression',
-            link_targets=[
+        link = remote_das.get_links(link_filters.Targets(
+            [
                 metta_animal_base_handles.Inheritance,
                 metta_animal_base_handles.earthworm,
                 metta_animal_base_handles.animal,
             ],
-        )
-        assert next(link)['handle'] == metta_animal_base_handles.inheritance_earthworm_animal
+            'Expression'))
+        assert link[0]['handle'] == metta_animal_base_handles.inheritance_earthworm_animal
 
     def test_get_incoming_links(self, remote_das: DistributedAtomSpace):
         expected_handles = [

--- a/tests/performance/test_redis_mongo_benchmark.py
+++ b/tests/performance/test_redis_mongo_benchmark.py
@@ -1,4 +1,5 @@
 """Test node and link generation and Hyperon DAS load performance."""
+
 import random
 import re
 import statistics
@@ -139,9 +140,11 @@ class TestPerformance:
         test_name = request.node.name
         test_name = re.sub(
             regex,
-            lambda m: ""
-            if (m.start() == [match.start() for match in re.finditer(regex, test_name)][7])
-            else m.group(),
+            lambda m: (
+                ""
+                if (m.start() == [match.start() for match in re.finditer(regex, test_name)][7])
+                else m.group()
+            ),
             request.node.name,
         )
         if test_name not in self.test_duration:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -6,7 +6,6 @@ import pytest
 from hyperon_das.cache.iterators import (
     BaseLinksIterator,
     ListIterator,
-    LocalGetLinks,
     LocalIncomingLinks,
     ProductIterator,
     RemoteIncomingLinks,
@@ -327,61 +326,6 @@ class TestRemoteIncomingLinks:
         result = iterator.get_fetch_data(cursor=0, chunk_size=100)
         assert result == (123, [{'handle': 'link1'}, {'handle': 'link2'}])
         backend.get_incoming_links.assert_called_once_with('atom1', cursor=0, chunk_size=100)
-
-
-class TestLocalGetLinks:
-    @pytest.fixture
-    def iterator(self):
-        link_type = 'Similarity'
-        cursor = 0
-        chunk_size = 500
-        target_types = ['Type1', 'Type2']
-        link_targets = ['Target1', 'Target2']
-        toplevel_only = True
-
-        source = ListIterator([1, 2, 3])
-
-        backend = mock.Mock()
-        backend._to_link_dict_list.side_effect = lambda x: [{'handle': x[0], 'name': f'Link{x[0]}'}]
-        backend._get_related_links.return_value = (
-            cursor,
-            [{'handle': 1, 'name': 'Link1'}, {'handle': 2, 'name': 'Link2'}],
-        )
-
-        return LocalGetLinks(
-            source,
-            backend=backend,
-            link_type=link_type,
-            target_types=target_types,
-            link_targets=link_targets,
-            toplevel_only=toplevel_only,
-            cursor=cursor,
-            chunk_size=chunk_size,
-        )
-
-    def test_get_next_value(self, iterator):
-        iterator.get_next_value()
-        assert iterator.current_value == {'handle': 1, 'name': 'Link1'}
-
-        iterator.get_next_value()
-        assert iterator.current_value == {'handle': 2, 'name': 'Link2'}
-
-        iterator.get_next_value()
-        assert iterator.current_value == {'handle': 3, 'name': 'Link3'}
-
-    def test_get_current_value(self, iterator):
-        current_value = iterator.get_current_value()
-        assert current_value == {'handle': 1, 'name': 'Link1'}
-
-    def test_get_fetch_data_kwargs(self, iterator):
-        fetch_data_kwargs = iterator.get_fetch_data_kwargs()
-        expected_kwargs = {'cursor': 0, 'chunk_size': 500, 'toplevel_only': True}
-        assert fetch_data_kwargs == expected_kwargs
-
-    def test_get_fetch_data(self, iterator):
-        fetch_data = iterator.get_fetch_data()
-        expected_fetch_data = (0, [{'handle': 1, 'name': 'Link1'}, {'handle': 2, 'name': 'Link2'}])
-        assert fetch_data == expected_fetch_data
 
 
 class TestTraverseLinksIterator:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -9,7 +9,6 @@ from hyperon_das.cache.iterators import (
     LocalGetLinks,
     LocalIncomingLinks,
     ProductIterator,
-    RemoteGetLinks,
     RemoteIncomingLinks,
     TraverseLinksIterator,
     TraverseNeighborsIterator,
@@ -383,86 +382,6 @@ class TestLocalGetLinks:
         fetch_data = iterator.get_fetch_data()
         expected_fetch_data = (0, [{'handle': 1, 'name': 'Link1'}, {'handle': 2, 'name': 'Link2'}])
         assert fetch_data == expected_fetch_data
-
-
-class TestRemoteGetLinks:
-    def test_get_next_value(self):
-        source = ListIterator([{'handle': 'handle1'}, {'handle': 'handle2'}, {'handle': 'handle3'}])
-        iterator = RemoteGetLinks(
-            source,
-            link_type='link_type',
-            target_types=['type1', 'type2'],
-            link_targets=['target1', 'target2'],
-            toplevel_only=True,
-        )
-
-        iterator.get_next_value()
-        assert iterator.current_value == {'handle': 'handle1'}
-
-        iterator.get_next_value()
-        assert iterator.current_value == {'handle': 'handle2'}
-
-        iterator.get_next_value()
-        assert iterator.current_value == {'handle': 'handle3'}
-
-        with pytest.raises(StopIteration):
-            iterator.get_next_value()
-
-    def test_get_current_value(self):
-        source = ListIterator([{'handle': 'handle1'}, {'handle': 'handle2'}, {'handle': 'handle3'}])
-        iterator = RemoteGetLinks(
-            source,
-            link_type='link_type',
-            target_types=['type1', 'type2'],
-            link_targets=['target1', 'target2'],
-            toplevel_only=True,
-        )
-
-        assert iterator.get_current_value() == {'handle': 'handle1'}
-
-        iterator.get_next_value()
-        assert iterator.get_current_value() == {'handle': 'handle1'}
-
-        iterator.get_next_value()
-        assert iterator.get_current_value() == {'handle': 'handle2'}
-
-        iterator.get_next_value()
-        assert iterator.get_current_value() == {'handle': 'handle3'}
-
-        with pytest.raises(StopIteration):
-            iterator.get_next_value()
-        assert iterator.get_current_value() is None
-
-    def test_get_fetch_data_kwargs(self):
-        source = ListIterator([{'handle': 'handle1'}, {'handle': 'handle2'}, {'handle': 'handle3'}])
-        iterator = RemoteGetLinks(
-            source,
-            link_type='link_type',
-            target_types=['type1', 'type2'],
-            link_targets=['target1', 'target2'],
-            toplevel_only=True,
-        )
-
-        kwargs = iterator.get_fetch_data_kwargs()
-        assert kwargs == {'cursor': 0, 'chunk_size': 1000, 'toplevel_only': True}
-
-    def test_get_fetch_data(self):
-        backend = mock.Mock()
-        backend.get_links.return_value = (
-            123,
-            [{'handle': 'link1'}, {'handle': 'link2'}, {'handle': 'link3'}],
-        )
-        iterator = RemoteGetLinks(
-            ListIterator([{'handle': 'handle1'}, {'handle': 'handle2'}, {'handle': 'handle3'}]),
-            link_type='link_type',
-            target_types=['type1', 'type2'],
-            link_targets=['target1', 'target2'],
-            toplevel_only=True,
-            backend=backend,
-        )
-
-        data = iterator.get_fetch_data(cursor=0, chunk_size=100)
-        assert data == (123, [{'handle': 'link1'}, {'handle': 'link2'}, {'handle': 'link3'}])
 
 
 class TestTraverseLinksIterator:


### PR DESCRIPTION
Resolves #338 

A new dataclass LinkFilters have been created to be passed as parameter to das.get_links(). This simplifies the API moving all optional parameters into a subclass of this dataclass.

Subclasses have been created to encompass each use case of the method:

* All links of a given type
* All links of a given type whose targets are of given types
* All links of a given type whose targets are as specified

For each of these use cases we have a subclass which expect the proper parameters in its constructor.

Default values for all fields are provided mainly to keep compliance with AtomDB and Faas code yet unchanged to use such new classes.

Two additional API changes have been implemented as side effect of this change:

* A new get_link_handles() method was created to return only the handle of the requested links instead of the whole documents
* The "no_iterator" parameter was removed from this method's API (and it will be removed from other methods in the near future). The way we implemented iteration on results is not compliant with the new AttentionBroker design so this aspect of queries in general will be redesigned and re-coded. For now, get_links() is called as if "no_iterator" is always true.